### PR TITLE
Require cabal 3.10.3.0

### DIFF
--- a/clash-cores.cabal
+++ b/clash-cores.cabal
@@ -48,7 +48,7 @@ flag nix
 custom-setup
   setup-depends:
     base,
-    Cabal
+    Cabal >= 3.10.3.0
 
 common basic-config
   default-language: Haskell2010


### PR DESCRIPTION
This is the earliest cabal release that includes the fix mentioned in https://github.com/clash-lang/clash-compiler/pull/2665#issuecomment-1939044550