### PR TITLE
Enable building against GHC 9.10

### DIFF
--- a/.ci/gitlab/branch.yaml
+++ b/.ci/gitlab/branch.yaml
@@ -38,6 +38,20 @@ tests-release:
     matrix:
       - GHC_VERSION: [9.6.6, 9.4.8, 9.2.8]
 
+tests-master:
+  stage: test
+  rules:
+    - if: $CLASH_BRANCH == "master"
+  needs: []
+  trigger:
+    include: .ci/gitlab/test.yaml
+    strategy: depend
+  variables:
+    CLASH_BRANCH: "$CLASH_BRANCH"
+  parallel:
+    matrix:
+      - GHC_VERSION: 9.10.1
+
 stack-build:
   extends: .common-local
   image: fpco/stack-build:lts-22.33

--- a/cabal.project-common
+++ b/cabal.project-common
@@ -1,4 +1,4 @@
-index-state: 2024-08-30T20:09:00Z
+index-state: 2024-12-04T12:55:18Z
 
 packages:
   clash-cores.cabal

--- a/clash-cores.cabal
+++ b/clash-cores.cabal
@@ -209,7 +209,7 @@ library
     reducers                >= 3.12.2 && < 4.0,
     text                    >= 1.2.2 && < 2.2,
     constraints             >= 0.9   && < 1.0,
-    template-haskell        >= 2.12.0.0 && < 2.22,
+    template-haskell        >= 2.12.0.0 && < 2.23,
 
 test-suite unit-tests
   import: basic-config


### PR DESCRIPTION
Building with GHC 9.10 requires slightly increased version bounds for `template-haskell`.