### PR TITLE
Add an Etherbone slave implementation

### DIFF
--- a/cabal.project-common
+++ b/cabal.project-common
@@ -32,3 +32,17 @@ package recursion-schemes
 -- with -O2 provides gains around 5% to 10% in simple benchmarks
 package regex-tdfa
     optimization: 2
+
+source-repository-package
+  type: git
+  location: https://github.com/cchalmers/circuit-notation.git
+  tag: 564769c52aa05b90f81bbc898b7af7087d96613d
+
+source-repository-package
+  type: git
+  location: https://github.com/clash-lang/clash-protocols.git
+  tag: febb041c32fa678e7ddb7d0e976516a5c56b03fc
+  subdir: clash-protocols-base clash-protocols
+
+allow-newer:
+  clash-protocols:tasty

--- a/clash-cores.cabal
+++ b/clash-cores.cabal
@@ -109,7 +109,7 @@ common basic-config
     clash-protocols,
     constraints               >= 0.9   && < 1.0,
     containers                >=0.5    && <0.8,
-    -- extra,
+    deepseq,
     ghc-typelits-extra        >= 0.3.2,
     ghc-typelits-knownnat     >= 0.6,
     ghc-typelits-natnormalise >= 0.6,
@@ -136,6 +136,12 @@ library
     Clash.Cores.Crc
     Clash.Cores.Crc.Internal
     Clash.Cores.Crc.Catalog
+    Clash.Cores.Etherbone
+    Clash.Cores.Etherbone.Base
+    Clash.Cores.Etherbone.RecordBuilder
+    Clash.Cores.Etherbone.RecordProcessor
+    Clash.Cores.Etherbone.WishboneMaster
+    Clash.Cores.Etherbone.ConfigMaster
     Clash.Cores.LatticeSemi.ECP5.Blackboxes.IO
     Clash.Cores.LatticeSemi.ECP5.IO
     Clash.Cores.LatticeSemi.ICE40.Blackboxes.IO
@@ -216,6 +222,11 @@ test-suite unit-tests
 
   other-modules:
     Test.Cores.Crc
+    Test.Cores.Etherbone
+    Test.Cores.Etherbone.Internal
+    Test.Cores.Etherbone.WishboneMaster
+    Test.Cores.Etherbone.RecordBuilder
+    Test.Cores.Etherbone.RecordProcessor
     Test.Cores.Internal.SampleSPI
     Test.Cores.LineCoding8b10b
     Test.Cores.Internal.Signals
@@ -238,7 +249,6 @@ test-suite unit-tests
   build-depends:
     clash-cores,
     clash-prelude-hedgehog,
-    deepseq,
     hedgehog,
     infinite-list,
     tasty                   >= 1.2 && < 1.6,

--- a/clash-cores.cabal
+++ b/clash-cores.cabal
@@ -106,6 +106,7 @@ common basic-config
 
   build-depends:
     base                      >= 4.18  && < 5,
+    clash-protocols,
     constraints               >= 0.9   && < 1.0,
     containers                >=0.5    && <0.8,
     -- extra,

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -42,6 +42,11 @@ let
           self.callCabal2nix "doctest-parallel" sources.doctest-parallel {};
         clash-prelude =
           self.callCabal2nix "clash-prelude" (sources.clash-compiler + "/clash-prelude") {};
+        # clash-protocols also requires tasty < 1.5, so we need to jailbreak.
+        clash-protocols-base =
+          pkgs.haskell.lib.doJailbreak (self.callCabal2nix "clash-protocols-base" (sources.clash-protocols + "/clash-protocols-base") {});
+        clash-protocols =
+          pkgs.haskell.lib.doJailbreak (self.callCabal2nix "clash-protocols" (sources.clash-protocols + "/clash-protocols") {});
         clash-lib =
           self.callCabal2nix "clash-lib" (sources.clash-compiler + "/clash-lib") {};
         clash-ghc =

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -1,4 +1,16 @@
 {
+    "circuit-notation": {
+        "branch": "master",
+        "description": "A plugin for circuit notation",
+        "homepage": null,
+        "owner": "cchalmers",
+        "repo": "circuit-notation",
+        "rev": "564769c52aa05b90f81bbc898b7af7087d96613d",
+        "sha256": "117kry20wxgxlpvrs050v96xvai8mq81vsrm6d8sbilc7d3cpxxh",
+        "type": "tarball",
+        "url": "https://github.com/cchalmers/circuit-notation/archive/564769c52aa05b90f81bbc898b7af7087d96613d.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "clash-compiler": {
         "branch": "1.8",
         "description": "Haskell to VHDL/Verilog/SystemVerilog compiler",
@@ -11,6 +23,18 @@
         "url": "https://github.com/clash-lang/clash-compiler/archive/49f33ea971eb52b1dbdb7b11dafe0849408001f6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "1.8.2"
+    },
+    "clash-protocols": {
+        "branch": "main",
+        "description": "a battery-included library for dataflow protocols",
+        "homepage": null,
+        "owner": "clash-lang",
+        "repo": "clash-protocols",
+        "rev": "febb041c32fa678e7ddb7d0e976516a5c56b03fc",
+        "sha256": "15dlqpjymmb2li4vsnz4jqgi2clazd372i18v8qalmpzp0xsfha3",
+        "type": "tarball",
+        "url": "https://github.com/clash-lang/clash-protocols/archive/febb041c32fa678e7ddb7d0e976516a5c56b03fc.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "doctest-parallel": {
         "branch": "main",
@@ -49,18 +73,6 @@
         "url": "https://github.com/hedgehogqa/haskell-hedgehog/archive/52c35cabe24de2a1c03e72dde9d04b64f81d1f44.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
         "version": "1.4"
-    },
-    "circuit-notation": {
-        "branch": "master",
-        "description": "A plugin for circuit notation",
-        "homepage": null,
-        "owner": "cchalmers",
-        "repo": "circuit-notation",
-        "rev": "19b386c4aa3ff690758ae089c7754303f3500cc9",
-        "sha256": "0qz2w6akxj51kq50rbl88bnjyxzd2798a9sn9jj1z2kak7a6kqbg",
-        "type": "tarball",
-        "url": "https://github.com/cchalmers/circuit-notation/archive/19b386c4aa3ff690758ae089c7754303f3500cc9.tar.gz",
-        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {
         "branch": "master",

--- a/src/Clash/Cores/Etherbone.hs
+++ b/src/Clash/Cores/Etherbone.hs
@@ -1,0 +1,103 @@
+{-# OPTIONS_GHC -fplugin=Protocols.Plugin #-}
+
+module Clash.Cores.Etherbone (
+  etherboneC
+) where
+
+import Clash.Cores.Etherbone.Base
+import Clash.Cores.Etherbone.ConfigMaster (configMasterC, ConfigReg)
+import Clash.Cores.Etherbone.RecordBuilder (recordBuilderC)
+import Clash.Cores.Etherbone.RecordProcessor (recordProcessorC)
+import Clash.Cores.Etherbone.WishboneMaster (wishboneMasterC)
+import Clash.Prelude
+import Protocols
+import qualified Protocols.Df as Df
+import Protocols.PacketStream
+import Protocols.Wishbone
+
+
+recordHandlerC :: forall dom dataWidth addrWidth dat configRegs .
+  ( HiddenClockResetEnable dom
+  , KnownNat dataWidth
+  , KnownNat addrWidth
+  , KnownNat configRegs
+  , BitPack dat
+  , NFDataX dat
+  , Show dat
+  , ShowX dat
+  , 1 <= BitSize dat
+  , BitSize dat ~ dataWidth * 8
+  , ByteSize dat ~ dataWidth
+  , addrWidth <= dataWidth * 8
+  , 4 <= dataWidth
+  , DivRU 64 (BitSize dat) * BitSize dat ~ 64
+  )
+  -- | Self-describing bus base address
+  => BitVector addrWidth
+  -- | Optional user-defined config registers
+  -> Signal dom (Vec configRegs ConfigReg)
+  -> Circuit (PacketStream dom dataWidth EBHeader)
+             ( PacketStream dom dataWidth EBHeader
+             , Wishbone dom Standard addrWidth dat)
+recordHandlerC sdbAddr userConfigRegs = circuit $ \psIn -> do
+  dpkt <- recordDepacketizerC -< psIn
+
+  (bypass, wbOp) <- recordProcessorC -< dpkt
+  [wbmIn, cfgIn] <- Df.fanout -< wbOp
+
+  (wbmRes, wbBus, wbmErr) <- wishboneMasterC -< wbmIn
+  cfgRes <- configMasterC @_ @_ @dat sdbAddr userConfigRegs -< (cfgIn, wbmErr)
+
+  psOut <- recordBuilderC -< (bypass, cfgRes, wbmRes)
+  idC -< (psOut, wbBus)
+{-# OPAQUE recordHandlerC #-}
+
+-- | The top Etherbone circuit.
+--
+-- @sdbAddr@ is the [Self-describing bus](https://ohwr.org/project/fpga-config-space)
+-- data base address. Each Etherbone node is supposed to have a SDB structure
+-- connected to the Wishbone bus according to the spec. It does function without
+-- but the default tooling and APIs from CERN make use of this.
+--
+-- @userConfigRegs@ are additional 64-bit registers that are placed in the
+-- config-space. The current implementation of the config-space is read-only.
+--
+-- The Wishbone bus attatched to this circuit determines the bus and address
+-- widths.
+etherboneC :: forall dom dataWidth addrWidth dat configRegs .
+  ( HiddenClockResetEnable dom
+  , KnownNat dataWidth
+  , KnownNat addrWidth
+  , KnownNat configRegs
+  , BitPack dat
+  , NFDataX dat
+  , Show dat
+  , ShowX dat
+  , 1 <= BitSize dat
+  , BitSize dat ~ dataWidth * 8
+  , ByteSize dat ~ dataWidth
+  , addrWidth <= dataWidth * 8
+  , 4 <= dataWidth
+  , DivRU 64 (BitSize dat) * BitSize dat ~ 64
+  )
+  -- | Self-describing bus base address
+  => BitVector addrWidth
+  -- | Optional user-defined config registers
+  -> Signal dom (Vec configRegs ConfigReg)
+  -> Circuit (PacketStream dom dataWidth ())
+             ( PacketStream dom dataWidth ()
+             , Wishbone dom Standard addrWidth dat)
+etherboneC sdbAddr userConfigRegs = circuit $ \psIn -> do
+  [probe, record] <- receiverC (SNat @addrWidth) <| etherboneDepacketizerC -< psIn
+
+  probeOut <- probeHandlerC (SNat @addrWidth) -< probe
+
+  record' <- etherbonePaddingStripperC -< record
+  (recordOut, wbmBus) <- recordHandlerC sdbAddr userConfigRegs -< record'
+  recordOut' <- etherbonePaddingAdderC -< recordOut
+
+  pktOut <- packetArbiterC Df.Parallel -< [recordOut', probeOut]
+  udpTx <- etherbonePacketizerC -< pktOut
+
+  idC -< (udpTx, wbmBus)
+{-# OPAQUE etherboneC #-}

--- a/src/Clash/Cores/Etherbone/Base.hs
+++ b/src/Clash/Cores/Etherbone/Base.hs
@@ -1,0 +1,286 @@
+{-# OPTIONS_GHC -fplugin=Protocols.Plugin #-}
+
+module Clash.Cores.Etherbone.Base where
+
+import Clash.Prelude
+import Control.DeepSeq (NFData)
+import Data.Maybe
+import Protocols
+import Protocols.PacketStream
+
+etherboneVersion :: Natural
+etherboneVersion = 1
+
+etherboneMagic :: BitVector 16
+etherboneMagic = 0x4e6f
+
+-- | Etherbone packet header
+-- For more information about the individual fields see the Etherbone spec.
+data EBHeader = EBHeader
+  { _magic     :: BitVector 16
+  , _version   :: BitVector 4
+  , _res       :: Bit
+  -- | No-Reads flag. Indicates that there are no reads in this etherbone
+  -- packet.
+  , _noReads   :: Bool
+  -- | Probe-Response flag. Indicates that this packet is a probe response.
+  , _probeResp :: Bool
+  -- | Probe-Flag. Indicates that this packet is a etherbone probe.
+  , _probeFlag :: Bool
+  -- | Width of address fields
+  -- This and the @_portSize@ are bitflag fields formatted as {8, 16, 32, 64}
+  -- wide corresponding to {1, 2, 4, 8} in the vector. See 'sizeMask'.
+  , _addrSize  :: BitVector 4
+  -- | Width of data bus
+  , _portSize  :: BitVector 4
+  } deriving (Generic, BitPack, NFDataX, NFData, Show, ShowX, Eq)
+
+-- | Header for each Record in an Etherbone packet.
+-- For more information see the Etherbone spec.
+data RecordHeader = RecordHeader
+  -- | Whether the @BaseRetAddr@ for the read values is in config space of the
+  -- originating device.
+  { _baseIsConfig  :: Bool
+  -- | The read operations are meant for the config space.
+  , _readIsConfig  :: Bool
+  -- | Read results should be written to a FIFO at BaseRetAddr at the remote.
+  , _readFifo      :: Bool
+  , _res0          :: Bit
+  -- | Whether the @CYC@ line should be dropped after this record.
+  , _cyc           :: Bool
+  -- | The write operations are meant for the config space.
+  , _writeIsConfig :: Bool
+  -- | Write to a local FIFO
+  , _writeFifo     :: Bool
+  , _res1          :: Bit
+  -- | Wishbone byte enable field
+  , _byteEn        :: BitVector 8
+  -- | Number of write entries in this record
+  , _wCount        :: Unsigned 8
+  -- | Number of read entries in this record
+  , _rCount        :: Unsigned 8
+  } deriving (Generic, BitPack, NFDataX, NFData, Show, ShowX, Eq)
+
+-- | The address space a WishboneOperation is meant for.
+data AddressSpace = WishboneAddressSpace | ConfigAddressSpace
+  deriving (Generic, Show, ShowX, NFDataX, NFData, Eq)
+
+-- | Input data for 'Clash.Cores.Etherbone.WishboneMaster.wishboneMasterC' and 'Clash.Cores.Etherbone.ConfigMaster.configMasterC'
+data WishboneOperation addrWidth selWidth dat
+  = WishboneOperation
+  { _opAddr      :: BitVector addrWidth
+  -- | Input data. This determines whether the operation is a read or a write.
+  -- Read for @Nothing@, write for @Just@.
+  , _opDat       :: Maybe dat
+  -- | Wishbone @sel@ field
+  , _opSel       :: BitVector selWidth
+  -- | Indicates whether the @busCycle@ line should be dropped after the
+  -- operation.
+  , _opDropCyc   :: Bool
+  -- | The address space this operation should act on.
+  , _opAddrSpace :: AddressSpace
+  -- | End-of-record. Indicates whether the operation is the last of this record.
+  , _opEOR       :: Bool
+  -- | End-of-packet. Indicates whether the operation is the last of the etherbone packet.
+  , _opEOP       :: Bool
+  -- | This is set if the @_abort@ bit is set in the incoming @PacketStream@.
+  -- The state machine should stop handling data and be kept in the initial
+  -- state while this is set.
+  -- It is assumed that this bit is set until the @_last@ of the packet was set.
+  -- This is the default behavior of 'depacketizerC'.
+  -- The master circuits should return __no Data__ while this is set.
+  , _opAbort     :: Bool
+  } deriving (Generic, Show, ShowX, NFDataX, NFData, Eq)
+
+-- | Output data from 'Clash.Cores.Etherbone.WishboneMaster.wishboneMasterC' and
+-- 'Clash.Cores.Etherbone.ConfigMaster.configMasterC'
+data WishboneResult dat
+  = WishboneResult
+  -- | @Nothing@ for a write and @Just dat@ for a read.
+  { _resDat  :: Maybe dat
+  -- | Forwarded End-of-record flag
+  , _resEOR  :: Bool
+  -- | Forwarded End-of-packet flag
+  , _resEOP  :: Bool
+  } deriving (Generic, Show, NFDataX, ShowX, NFData, Eq)
+
+-- | The data sent over the bypass line.
+-- It is not assured that the data on the bypass line is in sync with the data
+-- returned from the WishboneMaster. This means that the RecordBuilder should
+-- save the header and base address in its state.
+--
+-- By using a bypass line the state machine of the WishboneMaster can be made
+-- simpler and the RecordBuilder can know about the number of reads and writes
+-- before an operation is finished.
+data Bypass addrWidth = Bypass
+  -- | The 'RecordHeader' from the @_meta@ field.
+  { _bpHeader :: RecordHeader
+  -- | The @BaseRetAddr@ that needs to be returned if a read operation has is
+  -- sent.
+  , _bpBase   :: Maybe (BitVector addrWidth)
+  -- | The @_abort@ signal from the PacketStream. If this is @True@, no new data
+  -- will come from 'Clash.Cores.Etherbone.WishboneMaster.wishboneMasterC' and
+  -- 'Clash.Cores.Etherbone.RecordBuilder.recordBuilderC' should be set back
+  -- into its initial state.
+  , _bpAbort  :: Bool
+  } deriving (Generic, NFDataX, NFData, Show, ShowX, Eq)
+
+type ByteSize dat = DivRU (BitSize dat) 8
+
+-- | Extract 'EBHeader' data from a @PacketStream@ into the metadata.
+-- With a 64-bit bus this shifts the data-stream by 4 bytes.
+etherboneDepacketizerC :: forall dom dataWidth .
+ ( HiddenClockResetEnable dom, KnownNat dataWidth, 4 <= dataWidth )
+ => Circuit (PacketStream dom dataWidth ()) (PacketStream dom dataWidth EBHeader)
+etherboneDepacketizerC = depacketizerC const
+
+-- | Concat 'EBHeader' metadata back into the data stream. This gives
+-- backpressure for one cycle.
+etherbonePacketizerC :: forall dom dataWidth .
+  ( HiddenClockResetEnable dom, KnownNat dataWidth, 4 <= dataWidth )
+  => Circuit (PacketStream dom dataWidth EBHeader) (PacketStream dom dataWidth ())
+etherbonePacketizerC = packetizerC (const ()) id
+
+-- | Strips 4 bytes from the start of a packet in the case of a 64-bit wishbone
+-- bus and passes the input for a 32-bit bus.
+-- This is needed to get rid of the 'potential padding' in the case of a 64-bit
+-- bus.
+etherbonePaddingStripperC :: forall dom dataWidth .
+  ( HiddenClockResetEnable dom
+  , KnownNat dataWidth
+  , 4 <= dataWidth
+  )
+  => Circuit (PacketStream dom dataWidth EBHeader) (PacketStream dom dataWidth EBHeader)
+etherbonePaddingStripperC = case compareSNat (SNat @dataWidth) d4 of
+  SNatLE -> idC
+  SNatGT -> depacketizerC metaMap
+  where
+    metaMap :: Vec (dataWidth-4) (BitVector 8) -> EBHeader -> EBHeader
+    metaMap _ hdr = hdr
+
+-- | Adds 4 bytes of padding to the start of a packet in the case of a 64-bit
+-- wishbone bus. It passes the input for a 32-bit bus.
+-- Needed to apply the 'potential padding' in the case of a 64-bit wishbone bus.
+etherbonePaddingAdderC :: forall dom dataWidth .
+  ( HiddenClockResetEnable dom
+  , KnownNat dataWidth
+  , 4 <= dataWidth
+  )
+  => Circuit (PacketStream dom dataWidth EBHeader) (PacketStream dom dataWidth EBHeader)
+etherbonePaddingAdderC = case compareSNat (SNat @dataWidth) d4 of
+  SNatLE -> idC
+  SNatGT -> packetizerC id (const $ repeat @(dataWidth-4) (0 :: BitVector 8))
+
+-- | Extract 'RecordHeader' data from a @PacketStream@ into the metadata. Strips
+-- potential padding from the header. Splits an Etherbone packet @PacketStream@
+-- into separate Record @PacketStream@s. The added bool in the metadata
+-- indicates end-of-packet.
+--
+-- 'EBHeader' can be dropped. All the info in it is static and known.
+recordDepacketizerC :: forall dom dataWidth .
+  ( HiddenClockResetEnable dom, KnownNat dataWidth, 4 <= dataWidth )
+  => Circuit (PacketStream dom dataWidth EBHeader) (PacketStream dom dataWidth (Bool, RecordHeader))
+recordDepacketizerC = recordSplitterC |> depacketizerC metaMap
+  where
+    metaMap
+      :: (RecordHeader, Vec (dataWidth - 4) (BitVector 8))
+      -> Bool
+      -> (Bool, RecordHeader)
+    metaMap hdr b = (b, fst hdr)
+
+    -- This circuit splits a Etherbone @PacketStream@ into separate Record
+    -- streams. The @_last@ field indicates a end-of-record.
+    -- The metadata is replaced by a Bool indicating end-of-packet.
+    recordSplitterC = Circuit $ mealyB recordSplitterT 0
+    recordSplitterT
+      -- | Counter of the number of words left in a record. A record can hold at
+      -- most 256 write and 256 read operations. So, with the base addresses, at
+      -- most 514 words. Rounded up, this requires 10 bits.
+      :: Unsigned 10
+      -> (Maybe (PacketStreamM2S dataWidth meta), PacketStreamS2M)
+      -> (Unsigned 10, (PacketStreamS2M, Maybe (PacketStreamM2S dataWidth Bool)))
+    recordSplitterT 0 (Nothing, _) = (0, (PacketStreamS2M True, Nothing))
+    recordSplitterT 0 (Just ps, oBwd) = (st', (oBwd, Just ps {_meta = False}))
+      where
+        wCount = bitCoerce $ resize $ _data ps !! (2 :: Integer)
+        rCount = bitCoerce $ resize $ _data ps !! (3 :: Integer)
+        wCount'
+          | wCount > 0 = wCount + 1
+          | otherwise  = 0
+        rCount'
+          | rCount > 0 = rCount + 1
+          | otherwise  = 0
+        st'
+          | _ready oBwd = wCount' + rCount'
+          | otherwise   = 0
+    recordSplitterT left (Nothing, _) = (left, (PacketStreamS2M True, Nothing))
+    recordSplitterT left (Just ps, oBwd) = (st', (oBwd, oFwd))
+      where
+        left'
+          | isJust $ _last ps = 0
+          | otherwise         = left - 1
+
+        st'
+          | _ready oBwd = left'
+          | otherwise   = left
+
+        oFwd = Just $ ps { _last = lst, _meta = isJust $ _last ps }
+        lst = if left' == 0 then Just maxBound else Nothing
+
+-- | Helper function to convert a dataWidth in bytes to the correct format for
+-- the @_addrSize@ and @_portSize@ fields in the 'EBHeader'.
+sizeMask :: Integer -> BitVector 4
+sizeMask n
+  | n == 1    = 0b0001
+  | n == 2    = 0b0010
+  | n == 4    = 0b0100
+  | n == 8    = 0b1000
+  | n > 8     = errorX "Etherbone v1 only supports up to 64-bit busses."
+  | otherwise = errorX "Only byte multiples of 2 are supported."
+
+-- | A dispatcher that validates incoming packets and dispatches them to the
+-- appropriate path. Either to the @ProbeHandler@ or to the @RecordHandler@.
+receiverC :: forall dom dataWidth addrWidth .
+  ( HiddenClockResetEnable dom, KnownNat dataWidth, KnownNat addrWidth )
+  => SNat addrWidth
+  -> Circuit (PacketStream dom dataWidth EBHeader)
+             (Vec 2 (PacketStream dom dataWidth EBHeader))
+receiverC SNat = packetDispatcherC (probePredicate :> recordPredicate :> Nil)
+  where
+    isValid = and . sequenceA [validMagic, validVersion, validAddr, validPort]
+
+    validMagic    = (== etherboneMagic) . _magic
+    validVersion  = (== fromIntegral etherboneVersion) . _version
+    validAddr     = (/= 0) . (.&. addrSizeMask) . _addrSize
+    validPort     = (/= 0) . (.&. portSizeMask) . _portSize
+
+    probePredicate m = isValid m && _probeFlag m
+    recordPredicate = isValid
+
+    portSizeMask = sizeMask $ natToInteger @dataWidth
+    addrSizeMask = sizeMask $ natToInteger @(Div addrWidth 8)
+
+-- | The handler for Probe packets.
+-- Sets the appropriate header flags for a probe response, the Etherbone
+-- device's bus sizes and forwards the probe-id.
+--
+-- On a 32-bit bus the probe-id fits in a whole word. With a 64-bit bus it is
+-- half a word. So this circuit returns a @_last = Just 4@ for both bus sizes.
+-- Later components need to be able to handle this.
+probeHandlerC :: forall dom dataWidth addrWidth .
+  ( KnownNat dataWidth, KnownNat addrWidth )
+  -- | Address width
+  => SNat addrWidth
+  -> Circuit
+  (PacketStream dom dataWidth EBHeader)
+  (PacketStream dom dataWidth EBHeader)
+probeHandlerC SNat = mapMeta metaMap
+  where
+    metaMap m = m { _probeFlag = False, _probeResp = True, _noReads = True
+                  , _addrSize = _addrSize m .&. addrSizeMask
+                  , _portSize = _portSize m .&. portSizeMask
+                  }
+
+    portSizeMask = sizeMask $ natToInteger @dataWidth
+    addrSizeMask = sizeMask $ natToInteger @(Div addrWidth 8)
+{-# OPAQUE probeHandlerC #-}

--- a/src/Clash/Cores/Etherbone/ConfigMaster.hs
+++ b/src/Clash/Cores/Etherbone/ConfigMaster.hs
@@ -1,0 +1,105 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Clash.Cores.Etherbone.ConfigMaster where
+
+import Clash.Cores.Etherbone.Base
+import Clash.Prelude
+import Protocols
+import qualified Protocols.Df as Df
+
+import Data.Maybe
+
+type ConfigReg = BitVector 64
+
+-- | Transact (read) operations on the Config space.
+--
+-- Any @WishboneOperation@ with @ConfigAddressSpace@ is handled by this circuit.
+-- Writes are silently ignored. Read operations access the @configSpace@. Each
+-- register in this space is 64-bits, as defiend in the Etherbone specification.
+-- With @dataWidth@ configured as 32-bits, you would need two reads to read a
+-- full register.
+--
+-- The ConfigSpace has the following registers (at the specified index):
+--
+-- 0. Error register. Shift register that keeps track of errors on the WB bus.
+-- 1. Self-describing bus base address.
+-- 2. Packet counter. Counts the number of correctly received packets.
+configMasterC
+  :: forall dom addrWidth dat configRegs.
+  ( HiddenClockResetEnable dom
+  , KnownNat addrWidth
+  , KnownNat configRegs
+  , BitPack dat
+  , NFDataX dat
+  , Show dat
+  , 4 <= ByteSize dat
+  , 1 <= BitSize dat
+  , DivRU 64 (BitSize dat) * BitSize dat ~ 64
+  )
+  -- | Self-describing bus base address
+  => BitVector addrWidth
+  -- | Optional user-defined config registers
+  -> Signal dom (Vec configRegs ConfigReg)
+  -> Circuit ( Df.Df dom (WishboneOperation addrWidth (ByteSize dat) dat)
+             , CSignal dom (Maybe Bit)
+             )
+             (Df.Df dom (WishboneResult dat))
+configMasterC sdbAddress userConfigRegs = Circuit go
+  where
+    go ((iFwd, errBit), oBwd) = ((oBwd, pure ()), oFwd)
+      where
+        -- Shift register keeping track of wishbone bus errors.
+        errorReg = register (0 :: ConfigReg) $ errorRegT <$> errBit <*> errorReg
+        errorRegT Nothing  er = er
+        errorRegT (Just b) er = er .<<+ b
+
+        -- The SDB base address
+        sdbAddress' = pure $ resize sdbAddress
+
+        -- Count the number of packages received.
+        -- This is counting the number of 'end-of-packet' signals without an
+        -- 'abort'.
+        packetCounter = register (0 :: ConfigReg)
+          $ packetCounterT <$> packetCounter <*> iFwd <*> oBwd
+        packetCounterT cnt fwd (Ack bwd)
+          | isLast fwd && bwd && not (isAbort fwd) = cnt + 1
+          | otherwise = cnt
+        isLast  x = fromMaybe False $ Df.dataToMaybe (fmap _opEOP x)
+        isAbort x = fromMaybe False $ Df.dataToMaybe (fmap _opAbort x)
+
+        -- The Etherbone internal config registers
+        etherboneConfigRegs
+          =  errorReg
+          :> sdbAddress'
+          :> packetCounter
+          :> Nil
+
+        configSpace = (++) <$> bundle etherboneConfigRegs <*> userConfigRegs
+
+        reMap ::
+          ConfigReg -> Vec (DivRU 64 (BitSize dat)) (BitVector (BitSize dat))
+        reMap = bitCoerce
+
+        configSpaceRemapped = fmap (concatMap reMap) configSpace
+        outData = regSelect <$> iFwd <*> configSpaceRemapped
+        out dat inp = WishboneResult <$> dat <*> (_opEOR <$> inp) <*> (_opEOP <$> inp)
+        oFwd = out <$> outData <*> iFwd
+
+        -- Drops ops for the @WishboneAddressSpace@, write ops and ops with
+        -- abort set. Selects to correct Word from the @configSpace@.
+        regSelect ::
+          ( KnownNat n )
+          => Df.Data (WishboneOperation addrWidth (ByteSize dat) dat)
+          -> Vec n (BitVector (BitSize dat))
+          -> Df.Data (Maybe dat)
+        regSelect Df.NoData _ = Df.NoData
+        regSelect (Df.Data WishboneOperation{..}) cs
+          | _opAddrSpace == WishboneAddressSpace
+                          = Df.NoData
+          | _opAbort      = Df.NoData
+          | isJust _opDat = Df.Data Nothing
+          | otherwise     = Df.Data $ Just $ bitCoerce (cs !! index)
+            where
+              bitsToShift = natToNum @(CLog 2 (ByteSize dat))
+              index = shiftR _opAddr bitsToShift
+

--- a/src/Clash/Cores/Etherbone/RecordBuilder.hs
+++ b/src/Clash/Cores/Etherbone/RecordBuilder.hs
@@ -1,0 +1,311 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Clash.Cores.Etherbone.RecordBuilder where
+
+import Clash.Cores.Etherbone.Base
+import Clash.Prelude
+import Protocols
+import qualified Protocols.Df as Df
+import Protocols.PacketStream
+
+import Control.DeepSeq
+import Data.Maybe
+
+-- Convert a RecordHeader from incoming to outgoing
+hdrRx2Tx :: RecordHeader -> RecordHeader
+hdrRx2Tx hdr
+  = hdr { _baseIsConfig  = False
+        , _readIsConfig  = False
+        , _readFifo      = False
+        , _writeIsConfig = _baseIsConfig hdr
+        , _writeFifo     = _readFifo hdr
+        , _rCount        = 0
+        , _wCount        = _rCount hdr
+        }
+
+-- EBHeader properly formatted for an outgoing packet
+ebTxMeta :: forall dataWidth addrWidth. SNat dataWidth -> SNat addrWidth -> EBHeader
+ebTxMeta SNat SNat = EBHeader
+  { _magic      = etherboneMagic
+  , _version    = fromIntegral etherboneVersion
+  , _res        = 0
+  , _noReads    = True
+  , _probeResp  = False
+  , _probeFlag  = False
+  , _addrSize   = addrSizeMask
+  , _portSize   = portSizeMask
+  }
+  where
+    portSizeMask = sizeMask $ natToInteger @dataWidth
+    addrSizeMask = sizeMask $ natToInteger @(Div addrWidth 8)
+
+data RecordBuilderState
+  -- | Wait for a new packet.
+  -- For a write, write zeros and jump to @BaseWriteAddr@.
+  -- For a read, write the response header and jump to @BaseRetAddr@.
+  -- This state always gives backpressure, to make up for the lost cycle form
+  -- the record header depacketizer.
+  = Init
+  -- | Write zeros in the spot of the @baseWriteAddr@ in the reponse.
+  | BaseWriteAddr
+  -- | Write zeros for each finished write.
+  -- If second-to-last write, jump to @Header@.
+  | PadWrites {_writesLeft :: Unsigned 8}
+  -- | Write the response record header
+  | Header
+  -- | Write the @BaseRetAddr@. By now this is known and sent over the bypass
+  -- line.
+  | BaseRetAddr
+  -- | Write the returned values from the @WishboneMaster@.
+  | ReadValues
+  -- | Send an abort @PacketStream@ signal. This state is used to decouple the
+  -- @Bypass@ input from the @PacketStream@ output.
+  | Aborted
+  deriving (Generic, NFDataX, NFData, Show, ShowX, Eq)
+
+-- In the case of an abort, the state machine will be put into the @Aborted@
+-- state for one cycle. It then sends an 'end-of-packet' (by setting @_last@)
+-- with no data and @_abort@ asserted as well.
+-- The ConfigMaster and WishboneMaster __may not__ send anything after an abort
+-- was asserted. So there is no need to manage the incoming Df data lines.
+recordBuilderT :: forall addrWidth dataWidth dat .
+  ( KnownNat addrWidth
+  , KnownNat dataWidth
+  , BitPack dat
+  , BitSize dat ~ dataWidth * 8
+  , 4 <= dataWidth
+  )
+  => RecordBuilderState
+  -> ( Maybe (Bypass addrWidth)
+     , Df.Data (WishboneResult dat)  -- Config space
+     , Df.Data (WishboneResult dat)  -- Wishbone space
+     , PacketStreamS2M
+     )
+  -> ( RecordBuilderState
+     , (Ack, Maybe (PacketStreamM2S dataWidth EBHeader))
+     )
+recordBuilderT Init (Nothing, _, _, _) = (Init, (Ack True, Nothing))
+recordBuilderT Init (Just Bypass{_bpAbort=True}, _, _, _) = (Init, (Ack True, Nothing))
+recordBuilderT st@Init (Just Bypass{..}, _, _, PacketStreamS2M psBwd)
+  = (nextState, (Ack False, psFwd))
+  -- TODO: Get rid of the RecordWildcard uses here.
+  where
+    hdr = _bpHeader
+    st'
+      | _wCount hdr > 0 = BaseWriteAddr
+      | _rCount hdr > 0 = BaseRetAddr
+      | otherwise       = Init
+    nextState
+      | isJust psFwd && psBwd = st'
+      | otherwise             = st
+
+    datOut = case st' of
+      BaseWriteAddr -> Just $ repeat 0
+      BaseRetAddr   -> Just $ bitCoerce (pack $ hdrRx2Tx hdr) ++ repeat 0
+      Init          -> Nothing
+      _             -> error "Invalid next state? This is impossible."
+
+    psFwd = (\x -> PacketStreamM2S x Nothing meta False) <$> datOut
+    meta = ebTxMeta (SNat @dataWidth) (SNat @addrWidth)
+recordBuilderT st@BaseWriteAddr (Just Bypass{..}, _, _, PacketStreamS2M psBwd)
+  = (nextState, (Ack False, psFwd))
+  where
+    hdr = _bpHeader
+    st'
+      | _bpAbort         = Aborted
+      | _wCount hdr == 1 = Header
+      | otherwise        = PadWrites (_wCount hdr - 1)
+    nextState
+      | psBwd     = st'
+      | otherwise = st
+
+    psFwd = Just $ PacketStreamM2S (repeat 0) Nothing meta False
+    meta = ebTxMeta (SNat @dataWidth) (SNat @addrWidth)
+recordBuilderT st@PadWrites{..} (Just Bypass{..}, cfg, wbm, PacketStreamS2M psBwd)
+  = (nextState, (Ack psBwd, psFwd))
+  where
+    hdr = _bpHeader
+    wCount' = _writesLeft - 1
+
+    st'
+      | _bpAbort    = Aborted
+      | wCount' > 0 = PadWrites wCount'
+      | otherwise   = Header
+    nextState
+      | isJust psFwd && psBwd = st'
+      | otherwise             = st
+
+    port
+      | _writeIsConfig hdr = cfg
+      | otherwise          = wbm
+
+    psFwd = case port of
+      Df.Data _ -> Just $ PacketStreamM2S (repeat 0) Nothing meta False
+      Df.NoData -> Nothing
+      where
+        meta = ebTxMeta (SNat @dataWidth) (SNat @addrWidth)
+recordBuilderT st@Header (Just Bypass{..}, cfg, wbm, PacketStreamS2M psBwd)
+  = (nextState, (Ack psBwd, psFwd))
+  where
+    hdr = _bpHeader
+
+    st'
+      | _bpAbort        = Aborted
+      | _rCount hdr > 0 = BaseRetAddr
+      | otherwise       = Init
+    nextState
+      | isJust psFwd && psBwd = st'
+      | otherwise             = st
+
+    port
+      | _writeIsConfig hdr = cfg
+      | otherwise          = wbm
+
+    psFwd = case port of
+      Df.Data r -> Just $ PacketStreamM2S headerDat (lst r) meta False
+      Df.NoData -> Nothing
+      where
+        headerDat = bitCoerce (pack (hdrRx2Tx hdr)) ++ repeat @(dataWidth - 4) 0
+        lst r = if _resEOP r then Just maxBound else Nothing
+        meta = ebTxMeta (SNat @dataWidth) (SNat @addrWidth)
+recordBuilderT st@BaseRetAddr (Just Bypass{..}, _, _, PacketStreamS2M psBwd)
+  = (nextState, (Ack False, psFwd))
+  where
+    st'
+      | _bpAbort          = Aborted
+      | isNothing _bpBase = BaseRetAddr
+      | otherwise         = ReadValues
+    nextState
+      | isJust psFwd && psBwd = st'
+      | otherwise             = st
+
+    psFwd = case _bpBase of
+      Just base -> Just $ PacketStreamM2S (bitCoerce $ resize base) Nothing meta False
+      Nothing   -> Nothing
+    meta = ebTxMeta (SNat @dataWidth) (SNat @addrWidth)
+recordBuilderT st@ReadValues (Just Bypass{..}, cfg, wbm, PacketStreamS2M psBwd)
+  = (nextState, (Ack psBwd, psFwd))
+  where
+    hdr = _bpHeader
+
+    st'
+      | _bpAbort  = Aborted
+      | otherwise = case port of
+        Df.Data p -> if _resEOR p then Init else ReadValues
+        Df.NoData -> ReadValues
+    nextState
+      | isJust psFwd && psBwd = st'
+      | otherwise             = st
+
+    port
+      | _readIsConfig hdr = cfg
+      | otherwise         = wbm
+
+    psFwd = case port of
+      Df.Data WishboneResult{_resDat=Just d, _resEOP}
+        -> Just $ PacketStreamM2S (bitCoerce d) (lst _resEOP) meta False
+      Df.Data WishboneResult{_resDat=Nothing}
+        -> deepErrorX "Each result should hold valid data."
+      Df.NoData -> Nothing
+      where
+        lst r = if r then Just maxBound else Nothing
+        meta = ebTxMeta (SNat @dataWidth) (SNat @addrWidth)
+recordBuilderT Aborted (_, _, _, PacketStreamS2M psBwd)
+  = (nextState, (Ack False, psFwd))
+  where
+    nextState
+      | psBwd     = Init
+      | otherwise = Aborted
+
+    psFwd = Just $ PacketStreamM2S (repeat 0) (Just 0) meta True
+    meta = ebTxMeta (SNat @dataWidth) (SNat @addrWidth)
+recordBuilderT _ (Nothing, _, _, _)
+  = error "This should not be possible. Only the 'Init' and 'Aborted' states can receive an empty Bypass signal."
+
+bypassLatchT ::
+  ( KnownNat addrWidth )
+  => Maybe (Bypass addrWidth)
+  -> (Maybe (Bypass addrWidth), Bool, Bool)
+  -> (Maybe (Bypass addrWidth), Maybe (Bypass addrWidth))
+bypassLatchT Nothing (Nothing, True, _) = deepErrorX "Cannot get a last signal with no bypass data and nothing latched."
+bypassLatchT Nothing (Nothing, False, _) = (Nothing, Nothing)
+bypassLatchT Nothing (Just bp, lst, bwd) = (st', Just bp)
+  where
+    st'
+      | _bpAbort bp = Nothing
+      | lst && bwd  = Nothing
+      | otherwise   = Just bp
+bypassLatchT (Just bs) (Just bp, lst, bwd) = (nextState, Just res)
+  where
+    res = Bypass { _bpHeader = _bpHeader bs
+                 , _bpBase   = _bpBase bs <|> _bpBase bp
+                 , _bpAbort  = _bpAbort bp
+                 }
+    st'
+      | _bpAbort bp = Nothing
+      | lst         = Nothing
+      | otherwise   = Just res
+    nextState
+      | bwd       = st'
+      | otherwise = Just res
+bypassLatchT (Just bs) (Nothing, lst, bwd) = (nextState, Just bs)
+  where
+    st'
+      | _bpAbort bs = Nothing
+      | lst         = Nothing
+      | otherwise   = Just bs
+    nextState
+      | bwd       = st'
+      | otherwise = Just bs
+
+-- | This combines @WishboneResult@s from the @WishboneMaster@ and
+-- @ConfigMaster@ into a response packet. The header and @retBaseAddr@ comes
+-- through the bypass line.
+--
+-- The bypass line is used so that the builder does not have to wait on the
+-- wishbone bus to start constructing a packet. The data on the bypass line is
+-- latched in @bypassLatchT@ for as long as a packet takes to be completed.
+--
+-- This implementation waits not only for reads, but also for writes when
+-- constructing a response.
+recordBuilderC :: forall dom addrWidth dataWidth dat .
+  ( HiddenClockResetEnable dom
+  , KnownNat addrWidth
+  , KnownNat dataWidth
+  , BitPack dat
+  , BitSize dat ~ dataWidth * 8
+  , 4 <= dataWidth
+  )
+  => Circuit ( CSignal dom (Maybe (Bypass addrWidth))
+             , Df.Df dom (WishboneResult dat)  -- Config space
+             , Df.Df dom (WishboneResult dat)  -- Wishbone space
+             )
+             (PacketStream dom dataWidth EBHeader)
+recordBuilderC = Circuit go
+  where
+    go ((bypass, cfg, wbm), psBwd) = ((pure (), wbBwd, wbBwd), psFwd)
+      where
+        (wbBwd, psFwd) = mealyB recordBuilderT Init (bypassLatch, cfg, wbm, psBwd)
+
+        -- Check for an end-of-record from any of the masters. After each record
+        -- the @bypassLatch@ should be reset.
+        -- A master __may not__ send anything when it had not received an
+        -- operation specifically meant for it.
+        wbPorts = (\a b -> Df.dataToMaybe a <|> Df.dataToMaybe b) <$> wbm <*> cfg
+        isLast = maybe False _resEOR <$> wbPorts
+
+        -- Backward signal to masters, used by @bypassLatchT@ to check if a
+        -- fragment was handled fully.
+        -- Also check @Fwd@. If this is @Nothing@, @wbBwd@ cannot be read.
+        bypassBwd = (isJust <$> wbPorts) .&&. (bwd <$> wbBwd)
+          where bwd (Ack a) = a
+
+        -- The bypass signals are latched for the duration of a packet.
+        -- The Bypass record returned has a bias for earlier received fields for
+        -- @_bpHeader@ and @_bpBase@. For @_bpAbort@ the newest signal is always
+        -- returned.
+        bypassLatch :: Signal dom (Maybe (Bypass addrWidth))
+        bypassLatch = mealyB bypassLatchT Nothing (bypass, isLast, bypassBwd)
+        -- bypassLatch = mealyB bypassLatchT Waiting (bypass, isLast)
+{-# OPAQUE recordBuilderC #-}

--- a/src/Clash/Cores/Etherbone/RecordProcessor.hs
+++ b/src/Clash/Cores/Etherbone/RecordProcessor.hs
@@ -1,0 +1,206 @@
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Clash.Cores.Etherbone.RecordProcessor where
+
+import Clash.Cores.Etherbone.Base
+import Clash.Prelude
+import Protocols
+import qualified Protocols.Df as Df
+import Protocols.PacketStream
+
+import qualified Data.Bifunctor as B
+import Data.Maybe
+
+data RecordProcessorState addrWidth
+  -- | Initial state of the @RecordProcessor@.
+  -- In this state either a @BaseWriteAddr@ or a @BaseRetAddr@ is received. The
+  -- @_wCount@ and @_rCount@ fields determine whether the next state is @Write@
+  -- or @Read@.
+  = WriteOrReadAddr
+  -- | State to handle Write operations.
+  -- When @_writesLeft == 1@ the state progresses to @ReadAddr@ or to
+  -- @WaitForLast@.
+  | Write { _writesLeft :: Unsigned 8
+          -- ^ Number of write operations left to fullfill.
+          , _addr :: BitVector addrWidth
+          -- ^ The (incrementing) address to write to.
+          }
+  -- | Handle the @BaseRetAddr@. This is sent over the Bypass line.
+  | ReadAddr
+  -- | Handle Read operations.
+  -- When @_readsLeft == 1@ the state is set back to @WriteOrReadAddr@.
+  | Read  { _readsLeft :: Unsigned 8 }
+  -- Wait until @_last@ was set.
+  | WaitForLast
+  deriving (Show, Generic, ShowX, NFDataX)
+
+recordProcessorT :: forall dataWidth addrWidth dat .
+  ( KnownNat dataWidth
+  , KnownNat addrWidth
+  , BitPack dat
+  , BitSize dat ~ dataWidth * 8
+  , Show dat
+  )
+  => RecordProcessorState addrWidth
+  -> (Maybe (PacketStreamM2S dataWidth (Bool, RecordHeader))
+     , ((), Ack)
+     )
+  -> ( RecordProcessorState addrWidth
+     , ( PacketStreamS2M
+       , ( Maybe (Bypass addrWidth)
+         , Df.Data (WishboneOperation addrWidth dataWidth dat)
+         )
+       )
+     )
+-- No data in -> no data out
+recordProcessorT state (Nothing, _)
+  = (state, (PacketStreamS2M True, (Nothing, Df.NoData)))
+-- If in the initial state and abort is asserted, stay in this state.
+recordProcessorT WriteOrReadAddr (Just PacketStreamM2S{_abort=True}, _)
+  = (WriteOrReadAddr, (PacketStreamS2M True, (Nothing, Df.NoData)))
+recordProcessorT state (Just psFwd, ((), Ack wbAck))
+  = (nextState, (PacketStreamS2M psBwd, (bpOut, wbOut)))
+  where
+    nextState
+      | ack       = state'
+      | otherwise = state
+    state' = fsm state psFwd
+
+    psWord = pack $ _data psFwd
+    meta = _meta psFwd
+    eop = fst meta
+    hdr = snd meta
+
+    -- Cannot read the Ack channels if the forward channels are NoData.
+    ack = case state of
+      WriteOrReadAddr -> True
+      ReadAddr        -> True
+      _               -> wbAck
+    psBwd = ack
+
+    -- Only write wishbone operations in the @Write@ or @Read@ state
+    wbOut = case state of
+      Write i a -> Df.Data
+        $ WishboneOperation
+          { _opAddr = a
+          , _opDat = Just dat
+          , _opSel = sel
+          , _opDropCyc = dropCyc $ i + _rCount hdr
+          , _opAddrSpace = if _writeIsConfig hdr then ConfigAddressSpace else WishboneAddressSpace
+          , _opEOR = isLast
+          , _opEOP = eop
+          , _opAbort = abort
+          }
+      Read i -> Df.Data
+        $ WishboneOperation
+          { _opAddr = resize psWord
+          , _opDat = Nothing
+          , _opSel = sel
+          , _opDropCyc = dropCyc i
+          , _opAddrSpace = if _readIsConfig hdr then ConfigAddressSpace else WishboneAddressSpace
+          , _opEOR = isLast
+          , _opEOP = eop
+          , _opAbort = abort
+          }
+      _ -> Df.NoData
+      where
+        dat = bitCoerce $ _data psFwd
+        isLast = isJust $ _last psFwd
+        sel = resize $ _byteEn hdr
+        abort = _abort psFwd
+
+        -- Drop @CYC@ if this was requested. Also drop if this is the last
+        -- fragment of the packet.
+        dropCyc left = eop || (left == 1 && _cyc hdr)
+
+    -- The bypass line always receives data if data is streaming in.
+    bpOut = Just $ Bypass hdr base (_abort psFwd)
+      where
+        base = case (state, state') of
+          (WriteOrReadAddr, Read _) -> Just $ resize psWord
+          (ReadAddr, _)             -> Just $ resize psWord
+          _ -> Nothing
+
+    fsm
+      :: RecordProcessorState addrWidth
+      -> PacketStreamM2S dataWidth (Bool, RecordHeader)
+      -> RecordProcessorState addrWidth
+    -- If this is the last fragment of the packet, jump back to the initial
+    -- state. This can happen from any of the states.
+    fsm _ PacketStreamM2S{_last}
+      | isJust _last = WriteOrReadAddr
+    fsm st@WriteOrReadAddr PacketStreamM2S{..} = st'
+      where
+        meta' = snd _meta
+        wCount = _wCount meta'
+        rCount = _rCount meta'
+
+        st'
+          | wCount > 0 = Write wCount $ resize psWord
+          | rCount > 0 = Read rCount
+          | otherwise  = st
+    fsm Write{..} PacketStreamM2S{..} = st'
+      where
+        meta' = snd _meta
+        wCount = _writesLeft
+        wCount' = wCount - 1
+        rCount = _rCount meta'
+
+        addr'
+          -- If @writeFifo@ is set, the write address is a FIFO and should not
+          -- increment.
+          | _writeFifo meta' = _addr
+          | otherwise        = _addr + (natToNum @dataWidth)
+
+        st'
+          | wCount' == 0 =
+            if rCount > 0
+              then ReadAddr
+              else WaitForLast
+          | otherwise = Write wCount' addr'
+    fsm ReadAddr PacketStreamM2S{..} = (Read . _rCount . snd) _meta
+    fsm Read{..} _ = st'
+      where
+        rCount = _readsLeft
+        rCount' = rCount - 1
+
+        st'
+          | rCount' == 0 = WaitForLast
+          | otherwise    = Read rCount'
+    -- If there is more data than indicated in the header, the data is dropped.
+    -- When @_last@ is set, the state is set to @WriteOrReadAddr@
+    fsm WaitForLast _ = WaitForLast
+
+
+-- | Converts a @PacketStream@ of a Record into separate operations for the
+-- @WishboneMaster@.
+-- It also bypasses the @WishboneMaster@ with the @RecordHeader@ so that the
+-- @RecordBuilder@ does not have to wait for the wishbone bus to start
+-- constructing the response. The bypass line also holds the @BaseRetAddr@
+-- required in the response in the case of reads, and an abort signal.
+--
+-- This circuit makes use of the fact that the depacketizers set @_abort@ for
+-- the rest of a packet if it was toggled. This means that there is no need to
+-- have an additional state to handle aborts.
+--
+-- This circuit assumes that @_last@ is set to @maxBound@ for the final fragment
+-- of a Record packet, so that no additional edge-cases need to be handled here.
+-- The @Bool@ in the @_meta@ field indicates the end of a whole Etherbone
+-- packet, and is forwarded.
+recordProcessorC :: forall dom dataWidth addrWidth dat .
+  ( HiddenClockResetEnable dom
+  , KnownNat dataWidth
+  , KnownNat addrWidth
+  , BitPack dat
+  , Show dat
+  , BitSize dat ~ dataWidth * 8
+  )
+  => Circuit (PacketStream dom dataWidth (Bool, RecordHeader))
+             ( CSignal dom (Maybe (Bypass addrWidth))
+             , Df.Df dom (WishboneOperation addrWidth dataWidth dat)
+             )
+recordProcessorC = forceResetSanity |> Circuit (B.second unbundle . fsm . B.second bundle)
+  where
+    fsm = mealyB recordProcessorT WriteOrReadAddr
+{-# OPAQUE recordProcessorC #-}

--- a/src/Clash/Cores/Etherbone/WishboneMaster.hs
+++ b/src/Clash/Cores/Etherbone/WishboneMaster.hs
@@ -1,0 +1,136 @@
+{-# LANGUAGE RecordWildCards #-}
+
+module Clash.Cores.Etherbone.WishboneMaster where
+
+import Clash.Cores.Etherbone.Base
+import Clash.Prelude
+import Protocols
+import qualified Protocols.Df as Df
+import Protocols.Wishbone
+
+import qualified Data.Bifunctor as B
+import Data.Maybe
+
+data WishboneMasterState dat
+  -- | Wait for an incoming wishbone operation. If an op is available, it is
+  -- directly forwarded to the wishbone bus.
+  = WaitForOp  { _wbmCyc :: Bool }
+  -- | Wait for a termination signal from the wishbone bus.
+  | Busy
+  -- | Forward result and wait for an Ack. In this state, a new operation can
+  -- already be sent on the input, though only in the @WaitForOp@ state is it
+  -- being handled.
+  | WaitForAck { _wbmCyc :: Bool, _retDat :: Maybe dat, _isEOR :: Bool, isEOP :: Bool}
+  deriving (Generic, NFDataX, Show, Eq)
+
+wishboneMasterT :: forall addrWidth dat .
+  ( KnownNat addrWidth
+  , BitPack dat
+  , NFDataX dat
+  , Show dat
+  )
+  => WishboneMasterState dat
+  -> ( Df.Data (WishboneOperation addrWidth (ByteSize dat) dat)
+     , (Ack, WishboneS2M dat, ())
+     )
+  -> ( WishboneMasterState dat
+     , ( Ack
+       , ( Df.Data (WishboneResult dat)
+         , WishboneM2S addrWidth (ByteSize dat) dat
+         , Maybe Bit)
+       )
+     )
+-- This operation is for another @AddressSpace@.
+wishboneMasterT state (Df.Data WishboneOperation{_opAddrSpace=ConfigAddressSpace}, _)
+  = (state, (Ack True, (Df.NoData, wbEmpty, Nothing)))
+    where
+      wbEmpty = emptyWishboneM2S
+wishboneMasterT state (iFwd, (Ack oBwd, wbBwd, _))
+  = (nextState, (Ack iBwd, (oFwd, wbFwd, errBit)))
+  where
+    nextState = fsm state iFwd oBwd
+
+    wbErr = err wbBwd || retry wbBwd
+    wbTerm = acknowledge wbBwd || wbErr
+
+    oFwd = case state of
+      WaitForAck _ dat eor eop -> Df.Data $ WishboneResult dat eor eop
+      _                        -> Df.NoData
+
+    iBwd = case state of
+      WaitForOp _  -> False
+      Busy         -> False
+      WaitForAck{} -> oBwd
+
+    errBit = case (state, nextState) of
+      (Busy, WaitForAck{}) -> Just $ boolToBit wbErr
+      _                    -> Nothing
+
+    -- The wishbone bus receives the incoming operation in the transition from
+    -- @WaitForOp@ to @Busy@.
+    wbFwd = case (state, iFwd) of
+      (WaitForOp c, Df.NoData) -> wbEmpty   { strobe=False, busCycle=c }
+      (WaitForOp _, Df.Data i) -> (wbPkt i) { strobe=True,  busCycle=True }
+      (Busy, Df.NoData)        -> errorX "No input data in Busy state, this should be impossible!"
+      (Busy, Df.Data i)        -> (wbPkt i) { strobe=True,  busCycle=True }
+      (WaitForAck c _ _ _, _)  -> wbEmpty   { strobe=False, busCycle=c }
+    wbPkt WishboneOperation{..} = WishboneM2S
+      { addr                = _opAddr
+      , writeData           = fromJustX _opDat
+      , busSelect           = _opSel
+      , lock                = False
+      , busCycle            = deepErrorX "busCycle was not set"
+      , strobe              = deepErrorX "strobe was not set"
+      , writeEnable         = isJust _opDat
+      , cycleTypeIdentifier = Classic
+      , burstTypeExtension  = LinearBurst
+      }
+    wbEmpty = emptyWishboneM2S
+
+    fsm
+      :: WishboneMasterState dat  -- state
+      -> Df.Data (WishboneOperation addrWidth (ByteSize dat) dat)  -- iFwd
+      -> Bool                     -- oBwd
+      -> WishboneMasterState dat  -- nextState
+    fsm st@WaitForOp{} Df.NoData _ = st
+    fsm WaitForOp{} (Df.Data WishboneOperation{..}) _
+      | _opAbort  = WaitForOp False
+      | otherwise = Busy
+    fsm Busy{} Df.NoData _ = error "Sender did not keep Df channel constant!"
+    fsm Busy{} (Df.Data x) _
+      | wbTerm    = WaitForAck (not $ _opDropCyc x) (dat $ _opDat x) (_opEOR x) (_opEOP x)
+      | otherwise = Busy
+      where
+        dat Nothing  = Just $ readData wbBwd
+        dat (Just _) = Nothing
+    fsm st@WaitForAck{} _ False = st
+    fsm WaitForAck{..} _ True = WaitForOp _wbmCyc
+
+-- | Transact operations on the wishbone bus.
+--
+-- This is a Wishbone Classic implementation, meaning that the circuit will give
+-- backpressure while the wishbone bus is busy. Once the wishbone bus has set a
+-- termination signal, the circuit can receive a new operation.
+-- Only once the resulting data has been acknowledged by the @RecordBuillder@
+-- will this circuit start a new operation.
+--
+-- The @busCycle@ is controlled by the @_dropCyc@ bool in the incoming
+-- operation. If this is set, the @CYC@ line is dropped in the @WaitForAck@
+-- state and kept low until a new operation arives.
+wishboneMasterC
+  :: forall dom addrWidth dat .
+  ( HiddenClockResetEnable dom
+  , KnownNat addrWidth
+  , BitPack dat
+  , NFDataX dat
+  , Show dat
+  )
+  => Circuit (Df.Df dom (WishboneOperation addrWidth (ByteSize dat) dat))
+             ( Df.Df dom (WishboneResult dat)
+             , Wishbone dom Standard addrWidth dat
+             , CSignal dom (Maybe Bit)
+             )
+wishboneMasterC = Circuit $ B.second unbundle . fsm . B.second bundle
+  where
+    fsm = mealyB wishboneMasterT (WaitForOp False)
+{-# OPAQUE wishboneMasterC #-}

--- a/stack.yaml
+++ b/stack.yaml
@@ -21,4 +21,15 @@ extra-deps:
     commit: '49f33ea971eb52b1dbdb7b11dafe0849408001f6' # v1.8.2
     subdirs:
       - tests
+  - git: https://github.com/cchalmers/circuit-notation.git
+    commit: '564769c52aa05b90f81bbc898b7af7087d96613d'
+  - git: https://github.com/clash-lang/clash-protocols.git
+    commit: 'febb041c32fa678e7ddb7d0e976516a5c56b03fc'
+    subdirs:
+      - clash-protocols-base
+      - clash-protocols
   - hedgehog-1.4@sha256:9860ab34ab3951d9515c71b777d8c9c47610aae7339933e17d26ad9a4afa5618,4754
+
+allow-newer: true
+allow-newer-deps:
+  - clash-protocols

--- a/test/Test/Cores/Etherbone.hs
+++ b/test/Test/Cores/Etherbone.hs
@@ -1,0 +1,17 @@
+module Test.Cores.Etherbone (
+  tests,
+) where
+
+import Test.Tasty
+import qualified Test.Cores.Etherbone.WishboneMaster
+import qualified Test.Cores.Etherbone.RecordBuilder
+import qualified Test.Cores.Etherbone.RecordProcessor
+
+tests :: TestTree
+tests =
+  testGroup
+    "Etherbone"
+    [ Test.Cores.Etherbone.WishboneMaster.tests
+    , Test.Cores.Etherbone.RecordBuilder.tests
+    , Test.Cores.Etherbone.RecordProcessor.tests
+    ]

--- a/test/Test/Cores/Etherbone/Internal.hs
+++ b/test/Test/Cores/Etherbone/Internal.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Test.Cores.Etherbone.Internal where
+import qualified Clash.Prelude as C
+import Hedgehog
+import Clash.Cores.Etherbone.Base
+import Prelude
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+type WBData = C.BitVector 32
+type DataWidth = 4
+type AddrWidth = 32
+
+-- Read / write values used in the tests
+readVal :: WBData
+readVal = 0x55555555
+writeVal :: WBData
+writeVal = 0xaaaaaaaa
+
+genRecordHeader
+  :: Range.Range (C.Unsigned 8)
+  -> Range.Range (C.Unsigned 8)
+  -> Gen RecordHeader
+genRecordHeader wRange rRange = do
+  _wCount' :: C.Unsigned 8 <- Gen.integral wRange
+  _rCount' :: C.Unsigned 8 <- Gen.integral rRange
+
+  -- Ensure that there is at least one read or one write
+  ( _rCount, _wCount ) <- Gen.filter (\(r, w) -> (r+w) > 0) $ do
+    return (_rCount', _wCount')
+
+  _cyc <- Gen.bool
+  _readIsConfig <- Gen.bool
+  _writeIsConfig <- Gen.bool
+  _writeFifo <- Gen.bool
+
+  let
+    _baseIsConfig = False
+    _readFifo = False
+    _res0 = 0
+    _res1 = 0
+    _byteEn = C.resize $ C.pack $ C.replicate (C.SNat @DataWidth) (1::C.Bit)
+
+  pure RecordHeader
+      { _baseIsConfig
+      , _readIsConfig
+      , _readFifo
+      , _res0
+      , _cyc
+      , _writeIsConfig
+      , _writeFifo
+      , _res1
+      , _byteEn
+      , _wCount
+      , _rCount
+      }

--- a/test/Test/Cores/Etherbone/RecordBuilder.hs
+++ b/test/Test/Cores/Etherbone/RecordBuilder.hs
@@ -1,0 +1,135 @@
+{-# OPTIONS_GHC -fplugin=Protocols.Plugin #-}
+
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+{-# LANGUAGE ViewPatterns #-}
+
+module Test.Cores.Etherbone.RecordBuilder (
+  tests,
+) where
+
+import Test.Tasty
+import Test.Tasty.Hedgehog
+import Test.Tasty.TH
+
+import Hedgehog
+import qualified Hedgehog.Range as Range
+
+import qualified Clash.Prelude as C
+import Data.Maybe
+import Protocols
+import qualified Protocols.Df as Df
+import Prelude
+import Protocols.PacketStream
+import Clash.Cores.Etherbone.Base
+import Protocols.Hedgehog hiding (Test)
+import Test.Cores.Etherbone.Internal
+import Clash.Cores.Etherbone.RecordBuilder (hdrRx2Tx, ebTxMeta, recordBuilderC)
+
+-- TODO: Add multi-record testing
+
+testBaseAddr :: C.BitVector AddrWidth
+testBaseAddr = 0xdeadbeef
+
+genRecordBuilderInput :: C.Unsigned 8 -> C.Unsigned 8 -> Gen [(Bypass AddrWidth, WishboneResult WBData)]
+genRecordBuilderInput wMax rMax = do
+  hdr <- genRecordHeader (Range.linear 0 wMax) (Range.linear 0 rMax)
+
+  let
+    wCount = fromIntegral $ _wCount hdr
+    rCount = fromIntegral $ _rCount hdr
+
+    wbResW = replicate wCount $ WishboneResult Nothing False False
+    wbResR = replicate rCount $ WishboneResult (Just readVal) False False
+    wbRes' = wbResW <> wbResR
+    wbRes = init wbRes' <> [(last wbRes') {_resEOR=True, _resEOP=True}]
+
+    -- The bypass line is always kept constant. The base address is only used if
+    -- there are reads.
+    bypass = repeat $ Bypass hdr (Just testBaseAddr) False
+  pure $ zip bypass wbRes
+
+recordBuilderTest :: C.Unsigned 8 -> C.Unsigned 8 -> Property
+recordBuilderTest wMax rMax =
+  idWithModelSingleDomain
+    defExpectOptions {eoTrace=False}
+    (genRecordBuilderInput wMax rMax)
+    (C.exposeClockResetEnable recordBuilderModel)
+    (C.exposeClockResetEnable (ckt @C.System))
+  where
+    -- The @withModel@ functions do not support @CSignal@. Additionally, the
+    -- bypass signal and the @WishboneResult@ are always related. So they are
+    -- put in the same @Df@ signal, where the backwards signal on bypass is
+    -- being dropped.
+    ckt :: forall dom addrWidth dataWidth dat .
+      ( C.HiddenClockResetEnable dom
+      , C.KnownNat addrWidth
+      , C.KnownNat dataWidth
+      , C.BitPack dat
+      , C.BitSize dat ~ dataWidth C.* 8
+      , 4 C.<= dataWidth
+      )
+      => Circuit (Df.Df dom (Bypass addrWidth, WishboneResult dat))
+                 (PacketStream dom dataWidth EBHeader)
+    ckt = circuit $ \input -> do
+      [in0, in1] <- Df.fanout -< input
+      wb <- Df.snd -< in0
+      bp <- bypassC <| Df.fst -< in1
+
+      [wb0, wb1] <- Df.fanout -< wb
+
+      recordBuilderC -< (bp, wb0, wb1)
+      where
+        bypassC ::
+          Circuit (Df.Df dom (Bypass addrWidth))
+                  (CSignal dom (Maybe(Bypass addrWidth)))
+        bypassC = Circuit $ C.unbundle . fmap go . C.bundle
+          where
+            go (f, _) = (Ack True, out)
+              where out = Df.dataToMaybe f
+
+recordBuilderModel
+  :: [(Bypass AddrWidth, WishboneResult WBData)]
+  -> [PacketStreamM2S DataWidth EBHeader]
+recordBuilderModel [] = error "recordBuilderModel: No input data"
+recordBuilderModel inp@((fst -> bypassHead): _) = out
+  where
+    (_, wb) = unzip inp
+
+    hdr = _bpHeader bypassHead
+    base = _bpBase bypassHead
+
+    wCount = fromIntegral $ _wCount hdr
+    rCount = fromIntegral $ _rCount hdr
+
+    ebHdr = ebTxMeta (C.SNat @DataWidth) (C.SNat @AddrWidth)
+    txHdr = hdrRx2Tx hdr
+
+    outDat
+      | wCount > 0 && rCount > 0
+        = replicate (wCount+1) 0 <> [C.pack txHdr]
+        <> [fromJust base] <> replicate rCount readVal
+      | wCount > 0 = replicate (wCount+1) 0 <> [C.pack txHdr]
+      | rCount > 0 = [C.pack txHdr] <> [fromJust base] <> replicate rCount readVal
+      | otherwise = error "This model assumes at least one read or write"
+
+    pkt dat = PacketStreamM2S (C.bitCoerce dat) Nothing ebHdr False
+    out' = map pkt outDat
+
+    lst = _resEOP (last wb)
+    out = init out' <> [(last out') {_last=l}]
+      where l = if lst then Just maxBound else Nothing
+
+prop_recordBuilder_writes :: Property
+prop_recordBuilder_writes = recordBuilderTest 32 0
+
+prop_recordBuilder_reads :: Property
+prop_recordBuilder_reads = recordBuilderTest 0 32
+
+prop_recordBuilder_writesAndReads :: Property
+prop_recordBuilder_writesAndReads = recordBuilderTest 32 32
+
+
+tests :: TestTree
+tests = $(testGroupGenerator)

--- a/test/Test/Cores/Etherbone/RecordProcessor.hs
+++ b/test/Test/Cores/Etherbone/RecordProcessor.hs
@@ -1,0 +1,236 @@
+{-# OPTIONS_GHC -fplugin=Protocols.Plugin #-}
+
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE AllowAmbiguousTypes #-}
+
+module Test.Cores.Etherbone.RecordProcessor (
+  tests,
+) where
+
+import Test.Tasty
+import Test.Tasty.Hedgehog
+import Test.Tasty.TH
+
+import Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import qualified Clash.Prelude as C
+import Data.Maybe
+import Protocols
+import qualified Protocols.Df as Df
+import Prelude hiding (head, tail)
+import Protocols.PacketStream
+import Clash.Cores.Etherbone.Base
+import Protocols.Hedgehog hiding (Test)
+import Clash.Cores.Etherbone.RecordProcessor (recordProcessorC)
+import Test.Cores.Etherbone.Internal
+
+-- TODO: Add multi-record tests
+
+genRecordProcessorInput :: Gen [PacketStreamM2S DataWidth (Bool, RecordHeader)]
+genRecordProcessorInput = do
+  hdr <- genRecordHeader (Range.linear 0 32) (Range.linear 0 32)
+
+  readBase' :: WBData <- Gen.integral Range.linearBounded
+  writeBase' :: WBData <- Gen.integral Range.linearBounded
+
+  let
+    RecordHeader{..} = hdr
+
+    readBase
+      | _rCount > 0 = [readBase']
+      | otherwise   = []
+    writeBase
+      | _wCount > 0 = [writeBase']
+      | otherwise   = []
+
+    readVals = replicate (fromIntegral _rCount) readVal
+    writeVals = replicate (fromIntegral _wCount) writeVal
+
+    rawData = writeBase <> writeVals <> readBase <> readVals
+
+    pkt :: WBData -> PacketStreamM2S DataWidth (Bool, RecordHeader)
+    pkt dat = PacketStreamM2S (C.bitCoerce dat) Nothing (False, hdr) False
+
+    stream' = map pkt rawData
+    stream = setLast stream'
+      where
+        setLast [] = []
+        setLast xs = init xs <> [lastPs (last xs)]
+        lastPs x = x {_last = Just maxBound, _meta = (True, snd $ _meta x)}
+
+  pure stream
+
+prop_genRecordProcessorInput :: Property
+prop_genRecordProcessorInput = property $ do
+  stream <- forAll genRecordProcessorInput
+  let
+    head = case stream of
+      [] -> error "genRecordProcessorInput: empty input"
+      (x:_) -> x
+
+    hdr = snd $ _meta head
+    wCount = _wCount hdr
+    rCount = _rCount hdr
+
+  footnote ("rCount:" <> show rCount)
+  footnote ("wCount:" <> show wCount)
+  footnote ("stream Length:" <> show (length stream))
+
+  -- Validate the length
+  assert $ length stream == ( fromIntegral wCount + fromEnum (wCount > 0) +
+                              fromIntegral rCount + fromEnum (rCount > 0) )
+  -- Validate _last
+  assert $ _last (last stream) == Just maxBound
+
+-- Check whether the WishboneOperations are formatted correctly.
+prop_recordProcessor_wishbone :: Property
+prop_recordProcessor_wishbone =
+  idWithModelSingleDomain @C.System
+    defExpectOptions {eoSampleMax = 256}
+    genRecordProcessorInput
+    (C.exposeClockResetEnable (snd . recordProcessorModel))
+    (C.exposeClockResetEnable (ckt @C.System @DataWidth @AddrWidth @WBData))
+  where
+    ckt :: forall dom dataWidth addrWidth dat .
+      ( C.HiddenClockResetEnable dom
+      , C.KnownNat dataWidth
+      , C.KnownNat addrWidth
+      , C.BitPack dat
+      , C.BitSize dat ~ dataWidth C.* 8
+      , Show dat
+      )
+      => Circuit (PacketStream dom dataWidth (Bool, RecordHeader))
+                 (Df.Df dom (WishboneOperation addrWidth dataWidth dat))
+    ckt = Circuit go
+      where
+        go (iFwd, oBwd) = (iBwd, snd oFwd)
+          where
+            (iBwd, oFwd) = toSignals recordProcessorC (iFwd, (pure (), oBwd))
+
+-- Check whether the Bypass data returned is formatted correctly.
+prop_recordProcessor_bypass :: Property
+prop_recordProcessor_bypass = property $ do
+  inputs' <- forAll genRecordProcessorInput
+
+  let
+    ckt :: forall dom dataWidth addrWidth dat .
+      ( C.HiddenClockResetEnable dom
+      , C.KnownNat dataWidth
+      , C.KnownNat addrWidth
+      , C.BitPack dat
+      , C.BitSize dat ~ dataWidth C.* 8
+      , C.Show dat
+      )
+      => Circuit (PacketStream dom dataWidth (Bool, RecordHeader))
+                 (CSignal dom (Maybe(Bypass addrWidth)))
+    ckt = Circuit go
+      where
+        go (iFwd, oBwd) = (iBwd, fst oFwd)
+          where
+            (iBwd, oFwd) = toSignals (recordProcessorC @_ @_ @_ @dat) (iFwd, (oBwd, pure $ Ack True))
+
+    inputs = map Just inputs'
+    inputsS = zip inputs (repeat ())
+
+    res = take (length inputs) $ C.simulate (C.bundle . go . C.unbundle) inputsS
+      where
+        go = toSignals (C.withClockResetEnable C.clockGen C.resetGen C.enableGen (ckt @C.System @DataWidth @AddrWidth @WBData))
+
+    bypass = map (fromJust . snd) res
+
+    modelBypass = fst $ (recordProcessorModel @DataWidth @AddrWidth @WBData) inputs'
+  footnote $ "Circit output: " <> show bypass
+  footnote $ "Model output:  " <> show modelBypass
+
+  assert $ length bypass == length modelBypass
+  assert $ bypass == modelBypass
+
+recordProcessorModel :: forall dataWidth addrWidth dat .
+  ( C.KnownNat dataWidth
+  , C.KnownNat addrWidth
+  , C.BitPack dat
+  , C.BitSize dat ~ dataWidth C.* 8
+  , Show dat
+  )
+  => [PacketStreamM2S dataWidth (Bool, RecordHeader)]
+  -> ([Bypass addrWidth], [WishboneOperation addrWidth dataWidth dat])
+recordProcessorModel [] = error "recordProcessorModel: empty input"
+recordProcessorModel inputs@(head:tail) = (bypass, wbmInput)
+  where
+    meta = _meta head
+    hdr = snd meta
+    wCount = fromIntegral $ _wCount hdr
+    rCount = _rCount hdr
+
+    writeBase
+      | wCount > 0 = C.resize $ C.pack $ _data head
+      | otherwise  = 0
+    inputWrites = take wCount tail
+    inputReads
+      | wCount > 0 = drop (wCount + 2) inputs
+      | otherwise  = tail
+
+    createBypass input i = Bypass (snd $ _meta input) readBase (_abort input)
+      where
+        readBase
+          | rCount > 0 && i == iBase = Just $ addrConv input
+          | otherwise = Nothing
+        iBase
+          | wCount > 0 = wCount + 1
+          | otherwise  = 0
+        addrConv = C.resize . C.pack . _data
+
+    createWriteInput input i
+      = WishboneOperation
+        { _opAddr = addr
+        , _opDat = Just dat
+        , _opSel = C.resize $ _byteEn hdr
+        , _opDropCyc = False
+        , _opAddrSpace = space
+        , _opEOR = isJust $ _last input
+        -- XXX: Only one record per packet is tested here. So _opEOR = _opEOP
+        , _opEOP = isJust $ _last input
+        , _opAbort = _abort input
+        }
+      where
+        addr
+          | _writeFifo hdr = writeBase
+          | otherwise      = writeBase + (i * 4)
+        dat = C.bitCoerce $ _data input
+        space
+          | _writeIsConfig hdr = ConfigAddressSpace
+          | otherwise          = WishboneAddressSpace
+
+    createReadInput input
+      = WishboneOperation
+        { _opAddr = addr
+        , _opDat = Nothing
+        , _opSel = C.resize $ _byteEn hdr
+        , _opDropCyc = False
+        , _opAddrSpace = space
+        , _opEOR = isJust $ _last input
+        -- XXX: Only one record per packet is tested here. So _opEOR = _opEOP
+        , _opEOP = isJust $ _last input
+        , _opAbort = _abort input
+        }
+      where
+        addr = C.resize $ C.pack $ _data input
+        space
+          | _readIsConfig hdr = ConfigAddressSpace
+          | otherwise         = WishboneAddressSpace
+
+    wbmInput'
+      = zipWith createWriteInput inputWrites [0..]
+      <> map createReadInput inputReads
+
+    -- Set the last operation to drop Cyc.
+    -- The last fragment should always drop CYC to prevent a lock-up.
+    wbmInput = init wbmInput' <> [(last wbmInput') {_opDropCyc = True}]
+
+    bypass = zipWith createBypass inputs [0..]
+
+tests :: TestTree
+tests = $(testGroupGenerator)

--- a/test/Test/Cores/Etherbone/WishboneMaster.hs
+++ b/test/Test/Cores/Etherbone/WishboneMaster.hs
@@ -1,0 +1,109 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Test.Cores.Etherbone.WishboneMaster (
+  tests,
+) where
+
+import Test.Tasty
+import Test.Tasty.Hedgehog
+import Test.Tasty.TH
+
+import Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import Clash.Cores.Etherbone.WishboneMaster
+import qualified Clash.Prelude as C
+import Data.Maybe
+import Protocols
+import qualified Protocols.Df as Df
+import Protocols.Wishbone
+import Prelude
+import Clash.Cores.Etherbone.Base
+
+type WBData = C.BitVector 32
+
+genWishboneOperation :: Gen (WishboneOperation 32 4 WBData)
+genWishboneOperation = do
+  _opAddr :: C.BitVector 32 <- Gen.integral Range.linearBounded
+  _opDat :: Maybe WBData <- Gen.maybe $ Gen.integral Range.linearBounded
+  isLast <- Gen.bool
+  _opDropCyc <- Gen.bool
+  let
+    _opSel = 0xf :: C.BitVector 4
+
+    -- For now, no testing for _abort
+    -- TODO: Add testing of abort
+    _opAbort = False
+    _opAddrSpace = WishboneAddressSpace
+
+    _opEOR = isLast
+    _opEOP = isLast
+
+    input =
+      WishboneOperation
+        { _opAddr
+        , _opDat
+        , _opSel
+        , _opDropCyc
+        , _opAddrSpace
+        , _opEOR
+        , _opEOP
+        , _opAbort
+        }
+  pure input
+
+prop_wishboneMasterT :: Property
+prop_wishboneMasterT = property $ do
+  input <- forAll genWishboneOperation
+  wbTime :: Int <- forAll $ Gen.integral (Range.linear 1 10)
+  ackTime :: Int <- forAll $ Gen.integral (Range.linear 0 10)
+  let
+    beginWait = 5
+    readData = 0x55555555
+
+    wbTime' = wbTime + 1
+    ackTime' = ackTime + 1
+
+    -- Proper way to test this would be to create a model of the wishbone
+    -- system. Instead I generate input 'signals' that are properly timed.
+    input' = replicate beginWait Df.NoData <> replicate wbTime' (Df.Data input) <> replicate ackTime' Df.NoData
+    ackInput = replicate beginWait True <> replicate wbTime' False <> replicate (ackTime' - 1) False <> [True]
+    wbAckInput = replicate beginWait False <> replicate (wbTime' - 1) False <> [True] <> replicate ackTime' False
+
+    finalInput = map mapInput $ zip3 input' ackInput wbAckInput
+
+    (outStates, out) = foldl fn ([WaitForOp False], []) finalInput
+    fn (states, results) inp = (states ++ [state], results ++ [result])
+     where
+      (state, result) = wishboneMasterT (last states) inp
+
+    mapInput (x, ack, wbAck) =
+      (x, (Ack ack, (emptyWishboneS2M @WBData){readData = readData, acknowledge = wbAck}, ()))
+
+    getWb (_, (_, x, _)) = x
+    getOutDat (_, (Df.Data x, _, _)) = x
+    getOutDat (_, (_, _, _)) = error "No data at the expected cycle"
+  footnote (show input')
+  footnote (show outStates)
+  footnote (show out)
+
+  -- Check if it passes the correct states
+  assert $ outStates !! beginWait == WaitForOp False
+  assert $ outStates !! (beginWait + 1) == Busy
+  assert $ last outStates == WaitForOp (not $ _opDropCyc input)
+
+  -- Check if dropCyc works as expected
+  assert $ busCycle (getWb $ last out) == not (_opDropCyc input)
+
+  -- Check if data was read from the wishbone bus if a read op was submitted,
+  -- otherwise check if the returned data was 'Nothing'
+  assert $
+    _resDat (getOutDat $ out !! (beginWait + wbTime'))
+      == if isJust (_opDat input) then Nothing else Just readData
+
+  -- Check if EOR was set correctly
+  assert $ _resEOR (getOutDat $ out !! (beginWait + wbTime')) == _opEOR input
+
+tests :: TestTree
+tests = $(testGroupGenerator)

--- a/test/unit-tests.hs
+++ b/test/unit-tests.hs
@@ -14,6 +14,7 @@ import Prelude
 import Test.Tasty
 
 import qualified Test.Cores.Crc
+import qualified Test.Cores.Etherbone
 import qualified Test.Cores.LineCoding8b10b
 #if MIN_VERSION_clash_prelude(1,9,0)
 import qualified Test.Cores.Sgmii.AutoNeg
@@ -33,6 +34,7 @@ import qualified Test.Cores.Xilinx.Ethernet.Gmii
 tests :: TestTree
 tests = testGroup "Unittests" $
   [ Test.Cores.Crc.tests
+  , Test.Cores.Etherbone.tests
   , Test.Cores.LineCoding8b10b.tests
   , Test.Cores.SPI.tests
   , Test.Cores.SPI.MultiSlave.tests


### PR DESCRIPTION
This is a full implementation of the Slave side of Etherbone, which connects a Wishbone bus to another communication channel, such as Ethernet with UDP. It includes 32-bit and 64-bit bus and address width support, as well as the the ability to send multiple Etherbone Records in one Etherbone Packet.

This branch is rebased on top of `main`, as nothing inside the etherbone specific code depends on `ethernet`.

The example code and demo do depend on the ethernet branch. In the `etherbone-demo` branch (df0cd6615ec6e3dd1b80c1afd5e77838546c7dec) the ethernet branch is rebased on top of this branch, with the final commit adding the Xilinx demo code (in `src/Clash/Cores/Etherbone/Examples/`). I wanted to split this dependency from the PR so that this PR can be towards `main` rather than `ethernet`.

Also note that (94b6e453519e6bc12dca08b98eb32cf215efe707) pulls in the `Gmii` implementation from `clash-compiler/clash-cores`. I now realize this should probably be in the `etherbone-demo` branch.

Some relevant references:
- [Etherbone reference design and specification](https://ohwr.org/project/etherbone-core)
- [Self-describing bus and config space](https://ohwr.org/project/fpga-config-space)