### PR TITLE
SGMII core: resolve problems with packet transmission

### DIFF
--- a/src/Clash/Cores/Sgmii/Common.hs
+++ b/src/Clash/Cores/Sgmii/Common.hs
@@ -1,5 +1,5 @@
 {- |
-  Copyright   :  (C) 2024, QBayLogic B.V.
+  Copyright   :  (C) 2024, 2025, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 

--- a/src/Clash/Cores/Sgmii/Common.hs
+++ b/src/Clash/Cores/Sgmii/Common.hs
@@ -116,6 +116,11 @@ dwD05_6 = Dw 0b11000101
 dwD16_2 :: Symbol8b10b
 dwD16_2 = Dw 0b01010000
 
+-- | Data word corresponding to the first octet of the preamble of a packet,
+--   this replaces @Start_of_Packet@ (/S/) for newly received packets.
+dwD21_2 :: Symbol8b10b
+dwD21_2 = Dw 0b01010101
+
 -- | Data word corresponding to the decoded version of code group D21.5, used
 --   for alternating configuration transmission
 dwD21_5 :: Symbol8b10b

--- a/src/Clash/Cores/Sgmii/PcsReceive.hs
+++ b/src/Clash/Cores/Sgmii/PcsReceive.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE RecordWildCards #-}
 
 {- |
-  Copyright   :  (C) 2024, QBayLogic B.V.
+  Copyright   :  (C) 2024, 2025, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 

--- a/src/Clash/Cores/Sgmii/PcsReceive.hs
+++ b/src/Clash/Cores/Sgmii/PcsReceive.hs
@@ -242,7 +242,7 @@ pcsReceiveO s = case s of
     (s, Nothing, Nothing, Nothing, orNothing (_xmit s == Conf) RudiInvalid)
   IdleD{} -> (s, Just False, Just False, Nothing, Just RudiI)
   FalseCarrier{} -> (s, Nothing, Just True, Just (Cw 0b00001110), Nothing)
-  StartOfPacket{} -> (s, Just True, Just False, Just (Cw 0b01010101), Nothing)
+  StartOfPacket{} -> (s, Just True, Just False, Just dwD21_2, Nothing)
   EarlyEnd{} -> (s, Nothing, Just True, Nothing, Nothing)
   TriRri{} -> (s, Just False, Just False, Nothing, Nothing)
   TrrExtend{} -> (s, Just False, Just True, Just (Cw 0b00001111), Nothing)

--- a/src/Clash/Cores/Sgmii/PcsTransmit.hs
+++ b/src/Clash/Cores/Sgmii/PcsTransmit.hs
@@ -17,11 +17,22 @@ import Clash.Cores.Sgmii.PcsTransmit.CodeGroup
 import Clash.Cores.Sgmii.PcsTransmit.OrderedSet
 import Clash.Prelude
 
+-- | Tuple that contains a queue containing the most recent incoming octets and
+--   an 'Index' that points to the current octet to be transmitted. The size has
+--   been chosen to be 8, but this is a guess and could be too small.
 type InputDelayState = (Index 8, Vec 8 (Bool, Bool, BitVector 8))
 
+-- | Transition function for the input queue that outputs the correct octet when
+--   the system is ready. Note that, when the 'Index' that points to the next
+--   value to be outputted starts going down, it should act one time instance
+--   earlier than when it goes up.
 inputDelayT ::
+  -- | Current state
   InputDelayState ->
+  -- | New input values for @TX_EN@, @TX_ER@, the incoming data word and the
+  --   ready signal
   (Bool, Bool, BitVector 8, Bool) ->
+  -- | Output tuple without the ready signal
   (InputDelayState, (Bool, Bool, BitVector 8))
 inputDelayT (cur, is) (txEn, txEr, dw, txRdy) = ((cur', is'), o')
  where
@@ -41,6 +52,8 @@ inputDelayT (cur, is) (txEn, txEr, dw, txRdy) = ((cur', is'), o')
     | otherwise = is' !! cur
    where
     f (_, _, a) = (False, False, a)
+
+{-# OPAQUE inputDelayT #-}
 
 -- | Takes the signals that are defined in IEEE 802.3 Clause 36 and runs them
 --   through the state machines as defined for the PCS transmit block. These are

--- a/src/Clash/Cores/Sgmii/PcsTransmit.hs
+++ b/src/Clash/Cores/Sgmii/PcsTransmit.hs
@@ -7,7 +7,8 @@
   that are defined in the two submodules @CodeGroup@ and @OrderedSet@.
 -}
 module Clash.Cores.Sgmii.PcsTransmit
-  ( pcsTransmit
+  ( InputDelayState
+  , pcsTransmit
   , inputDelayT
   )
 where

--- a/src/Clash/Cores/Sgmii/PcsTransmit.hs
+++ b/src/Clash/Cores/Sgmii/PcsTransmit.hs
@@ -32,7 +32,7 @@ pcsTransmit ::
   Signal dom CodeGroup
 pcsTransmit txEn txEr dw xmit txConfReg = cg
  where
-  (_, cg, txEven, cgSent) =
+  (_, cg, txEven, txInd) =
     mooreB
       codeGroupT
       codeGroupO
@@ -43,6 +43,6 @@ pcsTransmit txEn txEr dw xmit txConfReg = cg
     mealyB
       orderedSetT
       (IdleS Idle False)
-      (txEn, txEr, dw, xmit, txEven, cgSent)
+      (txEn, txEr, dw, xmit, txEven, txInd)
 
 {-# OPAQUE pcsTransmit #-}

--- a/src/Clash/Cores/Sgmii/PcsTransmit/CodeGroup.hs
+++ b/src/Clash/Cores/Sgmii/PcsTransmit/CodeGroup.hs
@@ -1,5 +1,5 @@
 {- |
-  Copyright   :  (C) 2024, QBayLogic B.V.
+  Copyright   :  (C) 2024-2025, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
@@ -103,13 +103,13 @@ codeGroupO ::
   -- | Current state
   CodeGroupState ->
   -- | New output values
-  (CodeGroupState, CodeGroup, Even, Bool)
+  (CodeGroupState, CodeGroup, Even, Bool, Bool)
 codeGroupO s = case s of
-  SpecialGo{} -> (s, _cg s, nextEven (_txEven s), True)
-  DataGo{} -> (s, _cg s, nextEven (_txEven s), True)
-  IdleIB{} -> (s, _cg s, Odd, True)
-  ConfCB{} -> (s, _cg s, Odd, False)
-  ConfCD{} -> (s, _cg s, Odd, True)
-  _ -> (s, _cg s, Even, False)
+  SpecialGo{} -> (s, _cg s, nextEven (_txEven s), True, True)
+  DataGo{} -> (s, _cg s, nextEven (_txEven s), True, True)
+  IdleIB{} -> (s, _cg s, Odd, True, False)
+  ConfCB{} -> (s, _cg s, Odd, False, False)
+  ConfCD{} -> (s, _cg s, Odd, True, False)
+  _ -> (s, _cg s, Even, False, False)
 
 {-# OPAQUE codeGroupO #-}

--- a/src/Clash/Cores/Sgmii/PcsTransmit/OrderedSet.hs
+++ b/src/Clash/Cores/Sgmii/PcsTransmit/OrderedSet.hs
@@ -1,5 +1,5 @@
 {- |
-  Copyright   :  (C) 2024, QBayLogic B.V.
+  Copyright   :  (C) 2024, 2025, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 

--- a/test/Test/Cores/Sgmii/Sgmii.hs
+++ b/test/Test/Cores/Sgmii/Sgmii.hs
@@ -89,7 +89,7 @@ prop_loopbackTest = H.property $ do
 
   inp <- H.forAll (Gen.list (Range.singleton simDuration) genDefinedBitVector)
   let setupSamples = 77
-      delaySamples = 20
+      delaySamples = 28
       controlCount = 9
 
       simOut =
@@ -120,7 +120,7 @@ prop_duplexTransmission = H.property $ do
   inp1 <- H.forAll (Gen.list (Range.singleton simDuration) genDefinedBitVector)
   inp2 <- H.forAll (Gen.list (Range.singleton simDuration) genDefinedBitVector)
   let setupSamples = 77
-      delaySamples = 10
+      delaySamples = 14
       controlCount = 9
 
       inp = zip inp1 inp2
@@ -155,7 +155,7 @@ prop_duplexTransmissionCarrierExtend = H.property $ do
   inp3 <- H.forAll (Gen.list (Range.singleton simDuration) genDefinedBitVector)
   inp4 <- H.forAll (Gen.list (Range.singleton simDuration) genDefinedBitVector)
   let setupSamples = 77
-      delaySamples = 10
+      delaySamples = 14
       controlCount = 9
       extendCount = 2
 


### PR DESCRIPTION
This is a draft PR to resolve problems with packet transmission of the SGMII core. I will use this to track progress and mark observations.

Current actions:

- Discovered problem with packet transmission on hardware: some octets of the preamble are missing, and two extra empty (zero) octets are added before the `/T/` and `/R/` sequence indicating the end of a packet.
- Reproduced the issue in simulation: with the same input on `TXD` as in hardware, the issue can be reproduced in simulation.

Observations:

- While normally the preamble of an ethernet packet should be 7 times `0x55`, the intended output of the PCS transmit should only contain 6 times `0x55` as the start-of-packet code group `/S/` is replaced with `0x55` at the PCS receive.
- If `TX_EN` is asserted while the PCS receive code group process is in `IDLE_DISPARITY_WRONG` or `IDLE_DISPARITY_OK`, another octet of the preamble is missing as the system still needs to move through `IDLE_IB`.

Possible solution: add a queue for values coming from `TXD` that gets emptied when `TX_OSET.indicate` is issued, regardless of what the value of `TX_EN` is? This is thought-in-process.