### PR TITLE
Drop support for GHC versions older than 9.6

### DIFF
--- a/.ci/build_docs.sh
+++ b/.ci/build_docs.sh
@@ -41,4 +41,4 @@ if grep -q "${ambiguous_warn}" haddock_log; then
 fi
 
 # Copy documention to hadocs/
-ln -s "$(dirname "$(tail -n1 haddock_log)")" hadocs/
+ln -s "$(readlink -f "$(tail -n1 haddock_log)")" hadocs/clash-cores

--- a/.ci/cabal.project.local
+++ b/.ci/cabal.project.local
@@ -8,15 +8,6 @@ package *
   -- Dynamic executables save oozles of space when archiving it on CI
   executable-dynamic: True
 
-package clash-prelude
-  flags: -workaround-ghc-mmap-crash
-
-package clash-lib
-  flags: -workaround-ghc-mmap-crash
-
-package clash-ghc
-  flags: -workaround-ghc-mmap-crash
-
 package clash-cores
   ghc-options: -Werror
   tests: True
@@ -25,6 +16,3 @@ package clash-cores
   -- Cabal-the-library in combination with custom setup where the library path
   -- is not added to the RPATH
   executable-dynamic: False
-
-package clash-testsuite
-  flags: -workaround-ghc-mmap-crash

--- a/.ci/gitlab/branch.yaml
+++ b/.ci/gitlab/branch.yaml
@@ -60,7 +60,7 @@ stack-build:
   rules:
     - if: $CLASH_BRANCH == "release"
   variables:
-    CACHE_FALLBACK_KEY: $CI_JOB_NAME-master-$CI_JOB_IMAGE-1-3-non_protected
+    CACHE_FALLBACK_KEY: $CI_JOB_NAME-clash-$CLASH_BRANCH-main-$CI_JOB_IMAGE-$CACHE_BUST_TOKEN-non_protected
   before_script:
     - apt-get update
     - apt-get install -y zstd

--- a/.ci/gitlab/branch.yaml
+++ b/.ci/gitlab/branch.yaml
@@ -14,15 +14,10 @@ tests-always:
     strategy: depend
   variables:
     CLASH_BRANCH: "$CLASH_BRANCH"
+    CLASH_DOCKER_TAG: "$CLASH_DOCKER_TAG"
   parallel:
     matrix:
-      - GHC_VERSION: 9.8.2
-
-      - GHC_VERSION: 9.0.2
-        WORKAROUND_GHC_MMAP_CRASH: "yes"
-
-      - GHC_VERSION: 8.10.7
-        WORKAROUND_GHC_MMAP_CRASH: "yes"
+      - GHC_VERSION: ["9.6.6", "9.10.1"]
 
 tests-release:
   stage: test
@@ -34,10 +29,13 @@ tests-release:
     strategy: depend
   variables:
     CLASH_BRANCH: "$CLASH_BRANCH"
+    CLASH_DOCKER_TAG: "$CLASH_DOCKER_TAG"
   parallel:
     matrix:
-      - GHC_VERSION: [9.6.6, 9.4.8, 9.2.8]
+      - GHC_VERSION: ["9.8.4"]
 
+# Test GHC versions on master that our release version does
+# not support. In case there is no such GHC, set "matrix" to [] .
 tests-master:
   stage: test
   rules:
@@ -48,13 +46,13 @@ tests-master:
     strategy: depend
   variables:
     CLASH_BRANCH: "$CLASH_BRANCH"
+    CLASH_DOCKER_TAG: "$CLASH_DOCKER_TAG"
   parallel:
-    matrix:
-      - GHC_VERSION: 9.10.1
+    matrix: []
 
 stack-build:
   extends: .common-local
-  image: fpco/stack-build:lts-22.33
+  image: fpco/stack-build:lts-23.6
   needs: []
   stage: test
   rules:

--- a/.ci/gitlab/common.yaml
+++ b/.ci/gitlab/common.yaml
@@ -12,7 +12,6 @@ default:
   timeout: 10 minutes
   stage: build
   variables:
-    CLASH_DOCKER_TAG: 20240905
     CACHE_BUST_TOKEN: 1
     # Note that we copy+paste the image name into CACHE_FALLBACK_KEY. If we don't,
     # $GHC_VERSION gets inserted at verbatim, instead of resolving to some ghc version.

--- a/.ci/setup.sh
+++ b/.ci/setup.sh
@@ -26,12 +26,6 @@ cabal v2-update | tee cabal_update_output
 if [ ! -f cabal.project.local ]; then
   cp .ci/cabal.project.local .
 
-  set +u
-  if [[ "$WORKAROUND_GHC_MMAP_CRASH" == "yes" ]]; then
-    sed -i 's/-workaround-ghc-mmap-crash/+workaround-ghc-mmap-crash/g' cabal.project.local
-  fi
-  set -u
-
   # Fix index-state to prevent rebuilds if Hackage changes between build -> test.
   # Note we can't simply set it to a timestamp of "now", as Cabal will error out
   # when its index state is older than what's mentioned in cabal.project(.local).
@@ -45,11 +39,6 @@ cat cabal.project.local
 rm -f $HOME/.cabal/config
 cabal user-config init
 sed -i "s/-- ghc-options:/ghc-options: -j$THREADS/g" $HOME/.cabal/config
-set +u
-if [[ "$WORKAROUND_GHC_MMAP_CRASH" == "yes" ]]; then
-  sed -i "s/ghc-options:/ghc-options: +RTS -xm20000000 -RTS -with-rtsopts=-xm20000000/g" $HOME/.cabal/config
-fi
-set -u
 sed -i "s/^[- ]*jobs:.*/jobs: $CABAL_JOBS/g" $HOME/.cabal/config
 sed -i "/remote-repo-cache:.*/d" $HOME/.cabal/config
 cat $HOME/.cabal/config

--- a/.gitlab-ci.yaml
+++ b/.gitlab-ci.yaml
@@ -21,4 +21,7 @@ branches:
     strategy: depend
   parallel:
     matrix:
-      - CLASH_BRANCH: [release, master]
+      - CLASH_BRANCH: release
+        CLASH_DOCKER_TAG: 20250102
+      - CLASH_BRANCH: master
+        CLASH_DOCKER_TAG: 20250101

--- a/cabal.project-1.8
+++ b/cabal.project-1.8
@@ -2,10 +2,10 @@
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: v1.8.1
+  tag: v1.8.2
   subdir: tests
 
 constraints:
-  clash-prelude == 1.8.1,
-  clash-lib == 1.8.1,
-  clash-ghc == 1.8.1
+  clash-prelude == 1.8.2,
+  clash-lib == 1.8.2,
+  clash-ghc == 1.8.2

--- a/cabal.project-common
+++ b/cabal.project-common
@@ -1,4 +1,4 @@
-index-state: 2024-12-04T12:55:18Z
+index-state: 2025-01-29T13:43:13Z
 
 packages:
   clash-cores.cabal

--- a/clash-cores.cabal
+++ b/clash-cores.cabal
@@ -76,12 +76,6 @@ common basic-config
     TypeFamilies
     TypeOperators
 
-  -- See https://github.com/clash-lang/clash-compiler/pull/2511
-  if impl(ghc >= 9.4)
-    CPP-Options: -DCLASH_OPAQUE=OPAQUE
-  else
-    CPP-Options: -DCLASH_OPAQUE=NOINLINE
-
   ghc-options:
     -Wall -Wcompat
 
@@ -111,7 +105,7 @@ common basic-config
       -fplugin GHC.TypeLits.KnownNat.Solver
 
   build-depends:
-    base                      >= 4.10  && < 5,
+    base                      >= 4.18  && < 5,
     constraints               >= 0.9   && < 1.0,
     containers                >=0.5    && <0.8,
     ghc-typelits-extra        >= 0.3.2,
@@ -202,7 +196,7 @@ library
     ghc-prim                >= 0.3.1.0 && < 1.0,
     mtl                     >= 2.1.1 && < 2.4,
     pretty-show,
-    prettyprinter           >= 1.2.0.1  && < 1.8,
+    prettyprinter           >= 1.7 && < 1.8,
     prettyprinter-interp    ^>= 0.2,
     reducers                >= 3.12.2 && < 4.0,
     text                    >= 1.2.2 && < 2.2,

--- a/clash-cores.cabal
+++ b/clash-cores.cabal
@@ -112,7 +112,7 @@ common basic-config
 
   build-depends:
     base                      >= 4.10  && < 5,
-    constraints,
+    constraints               >= 0.9   && < 1.0,
     containers                >=0.5    && <0.8,
     ghc-typelits-extra        >= 0.3.2,
     ghc-typelits-knownnat     >= 0.6,
@@ -121,7 +121,7 @@ common basic-config
     lens,
     QuickCheck,
     string-interpolate        ^>= 0.3,
-    template-haskell,
+    template-haskell          >= 2.12.0.0 && < 2.23,
 
   if flag(clash-18)
     build-depends:
@@ -199,17 +199,14 @@ library
     -fno-worker-wrapper
 
   build-depends:
-    unordered-containers,
     ghc-prim                >= 0.3.1.0 && < 1.0,
-    lens,
     mtl                     >= 2.1.1 && < 2.4,
     pretty-show,
     prettyprinter           >= 1.2.0.1  && < 1.8,
     prettyprinter-interp    ^>= 0.2,
     reducers                >= 3.12.2 && < 4.0,
     text                    >= 1.2.2 && < 2.2,
-    constraints             >= 0.9   && < 1.0,
-    template-haskell        >= 2.12.0.0 && < 2.23,
+    unordered-containers,
 
 test-suite unit-tests
   import: basic-config
@@ -244,12 +241,12 @@ test-suite unit-tests
     clash-cores,
     clash-prelude-hedgehog,
     deepseq,
-    tasty        >= 1.2 && < 1.6,
+    hedgehog,
+    tasty                   >= 1.2 && < 1.6,
+    tasty-hedgehog          >= 1.2.0,
     tasty-hunit,
     tasty-quickcheck,
     tasty-th,
-    hedgehog,
-    tasty-hedgehog >= 1.2.0,
 
 test-suite doctests
   type:             exitcode-stdio-1.0

--- a/hdl-tests/cores-hdl-tests.cabal
+++ b/hdl-tests/cores-hdl-tests.cabal
@@ -64,9 +64,3 @@ executable cores-hdl-tests
   else
     build-depends:
       singletons < 3.0
-
-  -- See https://github.com/clash-lang/clash-compiler/pull/2511
-  if impl(ghc >= 9.4)
-    CPP-Options: -DCLASH_OPAQUE=OPAQUE
-  else
-    CPP-Options: -DCLASH_OPAQUE=NOINLINE

--- a/hdl-tests/shouldwork/Xilinx/DcFifo/Basic.hs
+++ b/hdl-tests/shouldwork/Xilinx/DcFifo/Basic.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 module Basic where
 
 import Clash.Explicit.Prelude
@@ -50,8 +48,7 @@ topEntity clk rst writeData rEnable =
     , dcOverflow=True
     , dcUnderflow=True
     }
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE topEntity #-}
+{-# OPAQUE topEntity #-}
 
 testBench ::
   Signal XilinxSystem Bool
@@ -82,8 +79,7 @@ testBench = done
         (fDone <$> fsmOut)
   clk = tbClockGen (not <$> done)
   en = enableGen
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE testBench #-}
+{-# OPAQUE testBench #-}
 
 data FsmOut = FsmOut
   { fDone :: Bool

--- a/hdl-tests/shouldwork/Xilinx/DcFifo/Lfsr.hs
+++ b/hdl-tests/shouldwork/Xilinx/DcFifo/Lfsr.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 module Lfsr where
@@ -37,8 +36,7 @@ lfsrF clk rst ena seed = msb <$> r
     five, three, two, zero :: Unsigned 16
     (five, three, two, zero) = (5, 3, 2, 0)
     lfsrFeedback = s ! five `xor` s ! three `xor` s ! two `xor` s ! zero
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE lfsrF #-}
+{-# OPAQUE lfsrF #-}
 
 fifoSampler ::
   KnownDomain dom =>
@@ -60,8 +58,7 @@ fifoSampler clk rst ena stalls inps =
    where
     maybeData = readLastCycle `orNothing` readData
     readNow = not stall && not fifoEmpty
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE fifoSampler #-}
+{-# OPAQUE fifoSampler #-}
 
 -- | Drives Xilinx FIFO with an ascending sequence of 'BitVector's. Stalls
 -- intermittently based on stall input.
@@ -163,41 +160,34 @@ fifoVerifier clk rst ena actual = done0
   done0 =
     assert clk rst "Doesn't time out" stuck (pure False) $
       assert clk rst "fifoVerifier" actual expected0 done
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE fifoVerifier #-}
+{-# OPAQUE fifoVerifier #-}
 
 topEntity_17_2 :: ConfiguredFifo (BitVector 16) Dom17 Dom2
 topEntity_17_2 = dcFifo defConfig
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE topEntity_17_2 #-}
+{-# OPAQUE topEntity_17_2 #-}
 {-# ANN topEntity_17_2 (defSyn "topEntity_17_2") #-}
 
 testBench_17_2 :: Signal Dom17 Bool
 testBench_17_2 = mkTestBench topEntity_17_2
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE testBench_17_2 #-}
+{-# OPAQUE testBench_17_2 #-}
 {-# ANN testBench_17_2 (TestBench 'topEntity_17_2) #-}
 
 topEntity_2_17 :: ConfiguredFifo (BitVector 16) Dom2 Dom17
 topEntity_2_17 = dcFifo defConfig
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE topEntity_2_17 #-}
+{-# OPAQUE topEntity_2_17 #-}
 {-# ANN topEntity_2_17 (defSyn "topEntity_2_17") #-}
 
 testBench_2_17 :: Signal Dom2 Bool
 testBench_2_17 = mkTestBench topEntity_2_17
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE testBench_2_17 #-}
+{-# OPAQUE testBench_2_17 #-}
 {-# ANN testBench_2_17 (TestBench 'topEntity_2_17) #-}
 
 topEntity_2_2 :: ConfiguredFifo (Unsigned 16) Dom2 Dom2
 topEntity_2_2 = dcFifo defConfig
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE topEntity_2_2 #-}
+{-# OPAQUE topEntity_2_2 #-}
 {-# ANN topEntity_2_2 (defSyn "topEntity_2_2") #-}
 
 testBench_2_2 :: Signal Dom2 Bool
 testBench_2_2 = mkTestBench topEntity_2_2
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE testBench_2_2 #-}
+{-# OPAQUE testBench_2_2 #-}
 {-# ANN testBench_2_2 (TestBench 'topEntity_2_2) #-}

--- a/hdl-tests/shouldwork/Xilinx/DnaPortE2.hs
+++ b/hdl-tests/shouldwork/Xilinx/DnaPortE2.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 module DnaPortE2 where
 
 import Clash.Explicit.Prelude
@@ -11,7 +9,7 @@ topEntity ::
   Reset XilinxSystem ->
   Signal XilinxSystem (Maybe (BitVector 96))
 topEntity clk rst = readDnaPortE2 clk rst enableGen simDna2
-{-# CLASH_OPAQUE topEntity #-}
+{-# OPAQUE topEntity #-}
 
 testBench :: Signal XilinxSystem Bool
 testBench = done
@@ -22,4 +20,4 @@ testBench = done
   done = outputVerifier' clk rst expected (topEntity clk rst)
   clk = tbClockGen (not <$> done)
   rst = noReset
-{-# CLASH_OPAQUE testBench #-}
+{-# OPAQUE testBench #-}

--- a/hdl-tests/shouldwork/Xilinx/Floating.hs
+++ b/hdl-tests/shouldwork/Xilinx/Floating.hs
@@ -5,8 +5,6 @@ License    :  BSD2 (see the file LICENSE)
 Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
 -}
 
-{-# LANGUAGE CPP #-}
-
 {-# OPTIONS_GHC -fconstraint-solver-iterations=10 -Wall -Werror #-}
 
 module Floating where
@@ -138,8 +136,7 @@ addBasic
   -> DSignal XilinxSystem 0 Float
   -> DSignal XilinxSystem F.AddDefDelay Float
 addBasic clk x y = withClock clk $ withEnable enableGen $ F.add x y
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE addBasic #-}
+{-# OPAQUE addBasic #-}
 {-# ANN addBasic (binaryTopAnn "addBasic") #-}
 
 addBasicTB :: Signal XilinxSystem Bool
@@ -157,8 +154,7 @@ addEnable
   -> DSignal XilinxSystem 0 Float
   -> DSignal XilinxSystem 11 Float
 addEnable clk en x y = withClock clk $ withEnable en $ F.add x y
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE addEnable #-}
+{-# OPAQUE addEnable #-}
 {-# ANN addEnable (binaryEnTopAnn "addEnable") #-}
 
 addEnableTB :: Signal XilinxSystem Bool
@@ -198,8 +194,7 @@ addShortPL
   -> DSignal XilinxSystem 6 Float
 addShortPL clk x y =
   withClock clk $ withEnable enableGen $ F.addWith F.defConfig x y
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE addShortPL #-}
+{-# OPAQUE addShortPL #-}
 {-# ANN addShortPL (binaryTopAnn "addShortPL") #-}
 
 addShortPLTB :: Signal XilinxSystem Bool
@@ -217,8 +212,7 @@ subBasic
   -> DSignal XilinxSystem 0 Float
   -> DSignal XilinxSystem F.SubDefDelay Float
 subBasic clk x y = withClock clk $ withEnable enableGen $ F.sub x y
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE subBasic #-}
+{-# OPAQUE subBasic #-}
 {-# ANN subBasic (binaryTopAnn "subBasic") #-}
 
 subBasicTB :: Signal XilinxSystem Bool
@@ -235,8 +229,7 @@ mulBasic
   -> DSignal XilinxSystem 0 Float
   -> DSignal XilinxSystem F.MulDefDelay Float
 mulBasic clk x y = withClock clk $ withEnable enableGen $ F.mul x y
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE mulBasic #-}
+{-# OPAQUE mulBasic #-}
 {-# ANN mulBasic (binaryTopAnn "mulBasic") #-}
 
 mulBasicTB :: Signal XilinxSystem Bool
@@ -253,8 +246,7 @@ divBasic
   -> DSignal XilinxSystem 0 Float
   -> DSignal XilinxSystem F.DivDefDelay Float
 divBasic clk x y = withClock clk $ withEnable enableGen $ F.div x y
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE divBasic #-}
+{-# OPAQUE divBasic #-}
 {-# ANN divBasic (binaryTopAnn "divBasic") #-}
 
 divBasicTB :: Signal XilinxSystem Bool
@@ -272,8 +264,7 @@ compareBasic
   -> DSignal XilinxSystem F.CompareDefDelay F.Ordering
 compareBasic clk x y =
   withClock clk $ withEnable enableGen $ F.compare x y
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE compareBasic #-}
+{-# OPAQUE compareBasic #-}
 {-# ANN compareBasic (binaryTopAnn "compareBasic") #-}
 
 compareBasicTB :: Signal XilinxSystem Bool
@@ -288,8 +279,7 @@ compareEnable
   -> DSignal XilinxSystem 0 Float
   -> DSignal XilinxSystem F.CompareDefDelay F.Ordering
 compareEnable clk en x y = withClock clk $ withEnable en $ F.compare x y
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE compareEnable #-}
+{-# OPAQUE compareEnable #-}
 {-# ANN compareEnable (binaryEnTopAnn "compareEnable") #-}
 
 compareEnableTB :: Signal XilinxSystem Bool
@@ -313,8 +303,7 @@ fromUBasic
   -> DSignal XilinxSystem 0 (Unsigned 32)
   -> DSignal XilinxSystem F.FromU32DefDelay Float
 fromUBasic clk x = withClock clk $ withEnable enableGen $ F.fromU32 x
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE fromUBasic #-}
+{-# OPAQUE fromUBasic #-}
 {-# ANN fromUBasic (unaryTopAnn "fromUBasic") #-}
 
 fromUBasicTB :: Signal XilinxSystem Bool
@@ -339,8 +328,7 @@ fromUEnable
   -> DSignal XilinxSystem 0 (Unsigned 32)
   -> DSignal XilinxSystem 5 Float
 fromUEnable clk en x = withClock clk $ withEnable en $ F.fromU32 x
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE fromUEnable #-}
+{-# OPAQUE fromUEnable #-}
 {-# ANN fromUEnable (unaryEnTopAnn "fromUEnable") #-}
 
 fromUEnableTB :: Signal XilinxSystem Bool
@@ -373,8 +361,7 @@ fromSBasic
   -> DSignal XilinxSystem 0 (Signed 32)
   -> DSignal XilinxSystem F.FromS32DefDelay Float
 fromSBasic clk x = withClock clk $ withEnable enableGen $ F.fromS32 x
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE fromSBasic #-}
+{-# OPAQUE fromSBasic #-}
 {-# ANN fromSBasic (unaryTopAnn "fromSBasic") #-}
 
 fromSBasicTB :: Signal XilinxSystem Bool
@@ -399,8 +386,7 @@ fromSEnable
   -> DSignal XilinxSystem 0 (Signed 32)
   -> DSignal XilinxSystem 6 Float
 fromSEnable clk en x = withClock clk $ withEnable en $ F.fromS32 x
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE fromSEnable #-}
+{-# OPAQUE fromSEnable #-}
 {-# ANN fromSEnable (unaryEnTopAnn "fromSEnable") #-}
 
 fromSEnableTB :: Signal XilinxSystem Bool

--- a/hdl-tests/shouldwork/Xilinx/Ila.hs
+++ b/hdl-tests/shouldwork/Xilinx/Ila.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module Ila where
@@ -20,8 +19,7 @@ type Dom = XilinxSystem
 
 top :: "result" ::: Unsigned 8
 top = 0
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE top #-}
+{-# OPAQUE top #-}
 makeTopEntity 'top
 
 oneCounter :: IlaConfig 1 -> Clock Dom -> Signal Dom ()

--- a/hdl-tests/shouldwork/Xilinx/TdpBlockRam.hs
+++ b/hdl-tests/shouldwork/Xilinx/TdpBlockRam.hs
@@ -2,7 +2,6 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ViewPatterns #-}
 
 module TdpBlockRam where
@@ -27,8 +26,7 @@ topEntity
   tdpbram
     clkA (toEnable enA) addrA byteEnaA datA
     clkB (toEnable enB) addrB byteEnaB datB
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE topEntity #-}
+{-# OPAQUE topEntity #-}
 
 tb ::
   ( KnownNat n0, KnownNat n1, KnownNat n2, KnownNat n3
@@ -72,8 +70,7 @@ tb inputA expectedA inputB expectedB =
   clkB :: Clock B
   clkB = tbClockGen (not <$> doneB)
 
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE normalWritesTB #-}
+{-# OPAQUE normalWritesTB #-}
 {-# ANN normalWritesTB (TestBench 'topEntity) #-}
 -- | Test bench doing some (non-overlapping) writes and reads on two ports, either
 -- with the byte enable fully set, or fully unset.
@@ -124,8 +121,7 @@ normalWritesTB = tb inputA expectedA inputB expectedB
     :> Nil
     ) ++ repeat @10 noOp
 
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE writeEnableWritesTB #-}
+{-# OPAQUE writeEnableWritesTB #-}
 {-# ANN writeEnableWritesTB (TestBench 'topEntity) #-}
 -- | Test bench doing some (non-overlapping) writes and reads on two ports, with
 -- varying byte enables.

--- a/hdl-tests/shouldwork/Xilinx/VIO.hs
+++ b/hdl-tests/shouldwork/Xilinx/VIO.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 module VIO where
@@ -23,8 +22,7 @@ type Dom = XilinxSystem
 
 top :: "result" ::: Unsigned 8
 top = 0
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE top #-}
+{-# OPAQUE top #-}
 
 makeTopEntity 'top
 

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,12 +5,12 @@
         "homepage": "https://clash-lang.org/",
         "owner": "clash-lang",
         "repo": "clash-compiler",
-        "rev": "3f5dc67c0e526e43a4dd88eb3902e39ed512c166",
-        "sha256": "022rwif8xkaabw0j3arhyj0hswmh3vq2nx1bbz8rbkp05jm4psgg",
+        "rev": "49f33ea971eb52b1dbdb7b11dafe0849408001f6",
+        "sha256": "102l671jr1jxvs8qmqxxrq5fdf254pcmjv9z1dwc7sbfbzy9jxqb",
         "type": "tarball",
-        "url": "https://github.com/clash-lang/clash-compiler/archive/3f5dc67c0e526e43a4dd88eb3902e39ed512c166.tar.gz",
+        "url": "https://github.com/clash-lang/clash-compiler/archive/49f33ea971eb52b1dbdb7b11dafe0849408001f6.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz",
-        "version": "1.8.1"
+        "version": "1.8.2"
     },
     "doctest-parallel": {
         "branch": "main",

--- a/src/Clash/Cores/LatticeSemi/ECP5/IO.hs
+++ b/src/Clash/Cores/LatticeSemi/ECP5/IO.hs
@@ -8,7 +8,6 @@
   <http://www.latticesemi.com/-/media/LatticeSemi/Documents/ApplicationNotes/EH/FPGA-TN-02032-1-2-ECP5-ECP5G-sysIO-Usage-Guide.ashx?document_id=50464>.
 -}
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE QuasiQuotes #-}
 
 {-# LANGUAGE ViewPatterns #-}
@@ -75,8 +74,7 @@ bbECP5 _intrinsicName pkgPinIn output notOutputEnable
      toMaybe :: Bool -> a -> Maybe a
      toMaybe True a  = Just a
      toMaybe False _ = Nothing
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE bbECP5 #-}
+{-# OPAQUE bbECP5 #-}
 {-# ANN bbECP5 hasBlackBox #-}
 {-# ANN bbECP5 (InlineYamlPrimitive [VHDL,Verilog,SystemVerilog] [__i|
   BlackBox:

--- a/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/IO.hs
+++ b/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/IO.hs
@@ -6,17 +6,10 @@
   HDL generation functionality for LATTICE ICE IO primitives.
 -}
 
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
 
 {-# OPTIONS_HADDOCK hide #-}
-
--- GHC < 9, sometimes(?) compains about the RHS of sbioTemplate being unreacheble,
--- this explicitly turns that into an warning overriding -Werror.
-#if __GLASGOW_HASKELL__ < 900
-{-# OPTIONS_GHC -Wwarn=overlapping-patterns #-}
-#endif
 
 module Clash.Cores.LatticeSemi.ICE40.Blackboxes.IO (sbioTF) where
 

--- a/src/Clash/Cores/LatticeSemi/ICE40/IO.hs
+++ b/src/Clash/Cores/LatticeSemi/ICE40/IO.hs
@@ -9,7 +9,6 @@
   referred to as LITL.
 -}
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -231,8 +230,7 @@ sbio pinConf pkgPinIn latchInput dOut_0 _dOut_1 outputEnable0 =
     writeToBiSignal
       pkgPinIn
       (toMaybe <$> outputEnable1 <*> pkgPinWriteInput)
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE sbio #-}
+{-# OPAQUE sbio #-}
 {-# ANN sbio hasBlackBox #-}
 {-# ANN sbio (InlineYamlPrimitive [VHDL,Verilog,SystemVerilog] [__i|
    BlackBox:

--- a/src/Clash/Cores/LineCoding8b10b.hs
+++ b/src/Clash/Cores/LineCoding8b10b.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 -- |
 --   Copyright   :  (C) 2024, QBayLogic B.V.
 --   License     :  BSD2 (see the file LICENSE)
@@ -72,7 +70,7 @@ decode8b10b rd cg = (rdNew, sym)
         $(memBlobTH Nothing Dec.decoderLut)
       $ unpack (pack rd ++# cg)
 
-{-# CLASH_OPAQUE decode8b10b #-}
+{-# OPAQUE decode8b10b #-}
 
 -- | Take the running disparity and the current 'Symbol8b10b', and return a
 --   tuple containing the new running disparity and a 'BitVector' containing the
@@ -95,4 +93,4 @@ encode8b10b rd sym = out
 
   out = if isValidSymbol sym then (rdNew, cg) else (rd, 0)
 
-{-# CLASH_OPAQUE encode8b10b #-}
+{-# OPAQUE encode8b10b #-}

--- a/src/Clash/Cores/Sgmii.hs
+++ b/src/Clash/Cores/Sgmii.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 {- |
   Copyright   :  (C) 2024, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
@@ -215,7 +213,7 @@ sgmii rxTxCdc rxClk txClk rxRst txRst txEn txEr txDw rxCg =
    where
     sgmiiRx' = exposeClockResetEnable sgmiiRx rxClk rxRst enableGen
 
-{-# CLASH_OPAQUE sgmii #-}
+{-# OPAQUE sgmii #-}
 
 -- | Receive side of the SGMII block, that combines all the functions that are
 --   in the receive domain, rate-adapted
@@ -322,4 +320,4 @@ sgmiiRA rxTxCdc rxClk txClk rxRst txRst txEr txDw rxCg =
    where
     sgmiiRx' = exposeClockResetEnable sgmiiRxRA rxClk rxRst enableGen
 
-{-# CLASH_OPAQUE sgmiiRA #-}
+{-# OPAQUE sgmiiRA #-}

--- a/src/Clash/Cores/Sgmii/AutoNeg.hs
+++ b/src/Clash/Cores/Sgmii/AutoNeg.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fconstraint-solver-iterations=10 #-}
 
 {- |
@@ -233,4 +232,4 @@ autoNeg syncStatus rudi = (xmit, txConfReg)
       (AnEnable Nothing 0 0)
       (syncStatus, rudi)
 
-{-# CLASH_OPAQUE autoNeg #-}
+{-# OPAQUE autoNeg #-}

--- a/src/Clash/Cores/Sgmii/BitSlip.hs
+++ b/src/Clash/Cores/Sgmii/BitSlip.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 
 {- |
@@ -97,4 +96,4 @@ bitSlip cg1 syncStatus = (register 0 cg2, register Fail bsStatus)
       (BSFail (0, 0) (repeat 0) (repeat 0))
       (cg1, syncStatus)
 
-{-# CLASH_OPAQUE bitSlip #-}
+{-# OPAQUE bitSlip #-}

--- a/src/Clash/Cores/Sgmii/PcsReceive.hs
+++ b/src/Clash/Cores/Sgmii/PcsReceive.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE RecordWildCards #-}
 
 {- |
@@ -296,4 +295,4 @@ pcsReceive cg rd dw1 rxEven syncStatus xmit = (rxDv, rxEr, dw2, rudi)
 
   xmit' = regMaybe Idle xmit
 
-{-# CLASH_OPAQUE pcsReceive #-}
+{-# OPAQUE pcsReceive #-}

--- a/src/Clash/Cores/Sgmii/PcsTransmit.hs
+++ b/src/Clash/Cores/Sgmii/PcsTransmit.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 {- |
   Copyright   :  (C) 2024, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
@@ -47,4 +45,4 @@ pcsTransmit txEn txEr dw xmit txConfReg = cg
       (IdleS Idle False)
       (txEn, txEr, dw, xmit, txEven, cgSent)
 
-{-# CLASH_OPAQUE pcsTransmit #-}
+{-# OPAQUE pcsTransmit #-}

--- a/src/Clash/Cores/Sgmii/PcsTransmit/CodeGroup.hs
+++ b/src/Clash/Cores/Sgmii/PcsTransmit/CodeGroup.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 {- |
   Copyright   :  (C) 2024, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
@@ -96,7 +94,7 @@ codeGroupT s (txOSet, dw, txConfReg) = nextState
   txConfReg' = fromMaybe (_txConfReg s) txConfReg
   (rd, cg) = encode8b10b (_rd s) dw'
 
-{-# CLASH_OPAQUE codeGroupT #-}
+{-# OPAQUE codeGroupT #-}
 
 -- | Output transition function for the states as defined in IEEE 802.3 Clause
 --   36, specifically Figure 36-6. This function takes the state values that
@@ -114,4 +112,4 @@ codeGroupO s = case s of
   ConfCD{} -> (s, _cg s, Odd, True)
   _ -> (s, _cg s, Even, False)
 
-{-# CLASH_OPAQUE codeGroupO #-}
+{-# OPAQUE codeGroupO #-}

--- a/src/Clash/Cores/Sgmii/PcsTransmit/OrderedSet.hs
+++ b/src/Clash/Cores/Sgmii/PcsTransmit/OrderedSet.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 {- |
   Copyright   :  (C) 2024, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
@@ -226,4 +224,4 @@ orderedSetT s@TxDataError{} (txEn, txEr, _, xmit, txEven, tx) = (nextState, out)
   s' = txTestXmit txEn txEr xmit' txEven tx xmitChange
   out = (s, OSetV)
 
-{-# CLASH_OPAQUE orderedSetT #-}
+{-# OPAQUE orderedSetT #-}

--- a/src/Clash/Cores/Sgmii/RateAdapt.hs
+++ b/src/Clash/Cores/Sgmii/RateAdapt.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-
 {- |
   Copyright   :  (C) 2024, QBayLogic B.V.
   License     :  BSD2 (see the file LICENSE)
@@ -48,7 +46,7 @@ rateAdaptRx ::
   Signal dom (Maybe a)
 rateAdaptRx linkSpeed a = mealyB rateAdaptRxT 0 (linkSpeed, a)
 
-{-# CLASH_OPAQUE rateAdaptRx #-}
+{-# OPAQUE rateAdaptRx #-}
 
 -- | State transition function for the transmit rate adaption function
 rateAdaptTxT ::
@@ -84,4 +82,4 @@ rateAdaptTx ::
   (Signal dom Bool, Signal dom (Maybe a))
 rateAdaptTx linkSpeed bv = mealyB rateAdaptTxT 0 (linkSpeed, bv)
 
-{-# CLASH_OPAQUE rateAdaptTx #-}
+{-# OPAQUE rateAdaptTx #-}

--- a/src/Clash/Cores/Sgmii/Sync.hs
+++ b/src/Clash/Cores/Sgmii/Sync.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ViewPatterns #-}
 
 {- |
@@ -188,4 +187,4 @@ sync rxCg =
   (_, cg, rd, dw, rxEven, syncStatus) =
     mooreB syncT syncO (LossOfSync 0 False (Dw 0) Even) rxCg
 
-{-# CLASH_OPAQUE sync #-}
+{-# OPAQUE sync #-}

--- a/src/Clash/Cores/Xilinx/BlockRam.hs
+++ b/src/Clash/Cores/Xilinx/BlockRam.hs
@@ -6,8 +6,6 @@
   Xilinx block RAM primitives
 -}
 
-{-# LANGUAGE CPP #-}
-
 -- See [Note: eta port names for tdpbram]
 {-# OPTIONS_GHC -fno-do-lambda-eta-expansion #-}
 
@@ -78,5 +76,4 @@ tdpbram clkA enA addrA byteEnaA datA clkB enB addrB byteEnaB datB =
       clashCompileError "tdpbram: domain A needs a rising active edge"
     (_, SFalling) ->
       clashCompileError "tdpbram: domain B needs a rising active edge"
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE tdpbram #-}
+{-# OPAQUE tdpbram #-}

--- a/src/Clash/Cores/Xilinx/BlockRam/Internal.hs
+++ b/src/Clash/Cores/Xilinx/BlockRam/Internal.hs
@@ -7,7 +7,6 @@
 -}
 
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -158,8 +157,7 @@ updateRam addr (IsDefined byteEna) dat mem
   isDefinedMaxBound _        = False
 
 {-# ANN tdpbram# hasBlackBox #-}
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE tdpbram# #-}
+{-# OPAQUE tdpbram# #-}
 {-# ANN tdpbram# (
    let
      primName = 'tdpbram#

--- a/src/Clash/Cores/Xilinx/DcFifo.hs
+++ b/src/Clash/Cores/Xilinx/DcFifo.hs
@@ -45,7 +45,6 @@ acknowledge, valid, or programmable full\/empty flags)
 Vivado 2022.1.)
 -}
 
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE RecordWildCards #-}
@@ -254,8 +253,7 @@ dcFifo DcConfig{..} wClk wRst rClk rRst writeData rEnable =
             Seq.EmptyR -> (q, deepErrorX "FIFO empty", True :- preUnder)
             qData Seq.:> qDatum -> (qData, qDatum, False :- preUnder)
         else (q, deepErrorX "Enable off", False :- preUnder)
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE dcFifo #-}
+{-# OPAQUE dcFifo #-}
 {-# ANN dcFifo (
    let primName = 'dcFifo
        tfName = 'dcFifoBBF

--- a/src/Clash/Cores/Xilinx/Floating/Explicit.hs
+++ b/src/Clash/Cores/Xilinx/Floating/Explicit.hs
@@ -43,7 +43,6 @@ type variable for delay annotation in circuits.
 -}
 
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE ViewPatterns #-}
 
 {-# OPTIONS_HADDOCK hide #-}
@@ -108,8 +107,7 @@ addWith !_ clk en (conditionFloatF -> x) (conditionFloatF -> y) =
   delayI und en clk . conditionFloatF $ x + y
  where
   und = withFrozenCallStack $ deepErrorX "Initial values of add undefined"
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE addWith #-}
+{-# OPAQUE addWith #-}
 {-# ANN addWith (vhdlBinaryPrim 'addWith 'addTclTF "add") #-}
 {-# ANN addWith (veriBinaryPrim 'addWith 'addTclTF "add") #-}
 
@@ -147,8 +145,7 @@ subWith !_ clk en (conditionFloatF -> x) (conditionFloatF -> y) =
   delayI und en clk . conditionFloatF $ x - y
  where
   und = withFrozenCallStack $ deepErrorX "Initial values of sub undefined"
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE subWith #-}
+{-# OPAQUE subWith #-}
 {-# ANN subWith (vhdlBinaryPrim 'subWith 'subTclTF "sub") #-}
 {-# ANN subWith (veriBinaryPrim 'subWith 'subTclTF "sub") #-}
 
@@ -187,8 +184,7 @@ mulWith !_ clk en (conditionFloatF -> x) (conditionFloatF -> y) =
   delayI und en clk . conditionFloatF $ x * y
  where
   und = withFrozenCallStack $ deepErrorX "Initial values of mul undefined"
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE mulWith #-}
+{-# OPAQUE mulWith #-}
 {-# ANN mulWith (vhdlBinaryPrim 'mulWith 'mulTclTF "mul") #-}
 {-# ANN mulWith (veriBinaryPrim 'mulWith 'mulTclTF "mul") #-}
 
@@ -227,8 +223,7 @@ divWith !_ clk en (conditionFloatF -> x) (conditionFloatF -> y) =
   delayI und en clk . conditionFloatF $ x / y
  where
   und = withFrozenCallStack $ deepErrorX "Initial values of div undefined"
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE divWith #-}
+{-# OPAQUE divWith #-}
 {-# ANN divWith (vhdlBinaryPrim 'divWith 'divTclTF "div") #-}
 {-# ANN divWith (veriBinaryPrim 'divWith 'divTclTF "div") #-}
 
@@ -266,8 +261,7 @@ fromU32With
 fromU32With clk en = delayI und en clk . fmap fromIntegral
  where
   und = withFrozenCallStack $ errorX "Initial values of fromU32 undefined"
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE fromU32With #-}
+{-# OPAQUE fromU32With #-}
 {-# ANN fromU32With (vhdlFromUPrim 'fromU32With "fromU32") #-}
 {-# ANN fromU32With (veriFromUPrim 'fromU32With "fromU32") #-}
 
@@ -304,8 +298,7 @@ fromS32With
 fromS32With clk en = delayI und en clk . fmap fromIntegral
  where
   und = withFrozenCallStack $ errorX "Initial values of fromS32 undefined"
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE fromS32With #-}
+{-# OPAQUE fromS32With #-}
 {-# ANN fromS32With (vhdlFromSPrim 'fromS32With "fromS32") #-}
 {-# ANN fromS32With (veriFromSPrim 'fromS32With "fromS32") #-}
 
@@ -346,8 +339,7 @@ compareWith
 compareWith clk ena a b = delayI und ena clk (xilinxCompare <$> a <*> b)
  where
   und = withFrozenCallStack $ errorX "Initial values of compare undefined"
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE compareWith #-}
+{-# OPAQUE compareWith #-}
 {-# ANN compareWith (vhdlComparePrim 'compareWith 'compareTclTF "compare") #-}
 {-# ANN compareWith (veriComparePrim 'compareWith 'compareTclTF "compare") #-}
 

--- a/src/Clash/Cores/Xilinx/Ila.hs
+++ b/src/Clash/Cores/Xilinx/Ila.hs
@@ -19,7 +19,6 @@ When using the generated ILAs make sure you have set the correct JTAG clock spee
 
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
@@ -117,7 +116,7 @@ ila ::
   a
 ila conf clk =
   ila# @dom @a conf clk
-{-# CLASH_OPAQUE ila #-}
+{-# OPAQUE ila #-}
 
 -- | Primitive for 'ila'. Defining a wrapper like this makes the ILA
 -- instantiation be rendered in its own module to reduce naming collision
@@ -129,8 +128,7 @@ ila# ::
   Clock dom ->
   a
 ila# !_conf !_clk = ilaX @dom @a
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE ila# #-}
+{-# OPAQUE ila# #-}
 {-# ANN ila# (
     let primName = 'ila#
         tfName = 'ilaBBF

--- a/src/Clash/Cores/Xilinx/Internal.hs
+++ b/src/Clash/Cores/Xilinx/Internal.hs
@@ -6,7 +6,6 @@
   Common utilities for defining Xilinx IP primitives.
 -}
 
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -20,16 +19,11 @@ import Prelude
 import Data.Maybe (catMaybes)
 import Data.Text (Text)
 import qualified Data.Text as Text
-#if MIN_VERSION_prettyprinter(1,7,0)
-import Prettyprinter
-  ((<+>), align, backslash, indent, line, pretty, rbrace, vsep)
-#else
-import Data.Text.Prettyprint.Doc
-  ((<+>), align, backslash, indent, line, pretty, rbrace, vsep)
-#endif
 import Data.Text.Prettyprint.Doc.Extra (Doc)
 import GHC.Natural (Natural)
 import GHC.Stack (HasCallStack)
+import Prettyprinter
+  ((<+>), align, backslash, indent, line, pretty, rbrace, vsep)
 import Prettyprinter.Interpolate (di, __di)
 
 import Clash.Netlist.Types (IdentifierText)
@@ -184,12 +178,12 @@ renderTcl = \case
       variable scriptPurpose createIp
       variable ipName {#{moduleName}}
       proc createIp {ipName0 args} {
-        create_ip \\\&
-          -name #{name} \\\&
-          -vendor #{vendor} \\\&
-          -library #{library} \\\&
-          -version #{version} \\\&
-          -module_name $ipName0 \\\&
+        create_ip \\
+          -name #{name} \\
+          -vendor #{vendor} \\
+          -library #{library} \\
+          -version #{version} \\
+          -module_name $ipName0 \\
           {*}$args
 
         set_property \\\&

--- a/src/Clash/Cores/Xilinx/VIO.hs
+++ b/src/Clash/Cores/Xilinx/VIO.hs
@@ -31,7 +31,6 @@ JTAG clock speed:
 
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE BangPatterns #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE QuasiQuotes #-}
@@ -114,7 +113,7 @@ vioProbe inputNames outputNames initialOutputProbeValues clk =
 -- Defining a NOINLINEd wrapper like this makes the 'vioProbe#'
 -- instantiation be rendered in its own module to reduce naming collision
 -- probabilities.
-{-# CLASH_OPAQUE vioProbe #-}
+{-# OPAQUE vioProbe #-}
 
 -- | Primitive for 'vioProbe'.
 vioProbe# ::
@@ -131,8 +130,7 @@ vioProbe# !_inputNames !_outputNames !_initialOutputProbeValues clk =
                  --
                  -- Fixes #2532
   vioX @dom @a @o
--- See: https://github.com/clash-lang/clash-compiler/pull/2511
-{-# CLASH_OPAQUE vioProbe# #-}
+{-# OPAQUE vioProbe# #-}
 {-# ANN vioProbe# (
     let primName = 'vioProbe#
         tfName = 'vioProbeBBF

--- a/src/Clash/Cores/Xilinx/Xpm/Cdc/Internal.hs
+++ b/src/Clash/Cores/Xilinx/Xpm/Cdc/Internal.hs
@@ -358,7 +358,7 @@ inst ::
   InstConfig ->
   a
 inst !_ = instX
-{-# CLASH_OPAQUE inst #-}
+{-# OPAQUE inst #-}
 {-# ANN inst (
     let
       primName = show 'inst

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2024-09-24
+resolver: lts-23.6
 
 ghc-options:
   "$locals": -Wall -Wcompat
@@ -12,12 +12,13 @@ flags:
     clash-18: true
 
 extra-deps:
+  - clash-prelude-1.8.2
+  - clash-lib-1.8.2
+  - clash-ghc-1.8.2
+  - clash-prelude-hedgehog-1.8.2
   - # clash-testsuite
     git: https://github.com/clash-lang/clash-compiler.git
-    commit: '3f5dc67c0e526e43a4dd88eb3902e39ed512c166' # v1.8.1
+    commit: '49f33ea971eb52b1dbdb7b11dafe0849408001f6' # v1.8.2
     subdirs:
       - tests
-  - # TODO: Remove this workaround. See:
-    #
-    # https://github.com/clash-lang/clash-compiler/pull/2665#issuecomment-1939044550
-    Cabal-3.10.3.0
+  - hedgehog-1.4@sha256:9860ab34ab3951d9515c71b777d8c9c47610aae7339933e17d26ad9a4afa5618,4754


### PR DESCRIPTION
If we require GHC 9.6, we can start really using features only present in newer GHC's. We can also drop quite some compatibility stuff and we make further development of the package easier.

 - With at least GHC 9.2, we can use `OverloadedRecordDot`
 - GHC 9.2 itself doesn't work well with Clash. It has indecipherable error messages.
 - With at least GHC 9.4, we can use `OPAQUE`
 - GHC 9.4 itself doesn't work well with Clash. Versions 9.4.8 is extremely slow.

Possibly there are several more good reasons as well, this list is not meant to be exhaustive.

Several open PR's require `clash-protocols` as a dependency. Adding that dependency already meant dropping support for GHC 8.10; it was what triggered this PR to be written.