### PR TITLE
Add regression test for issue 2781

### DIFF
--- a/hdl-tests/Main.hs
+++ b/hdl-tests/Main.hs
@@ -321,6 +321,7 @@ runClashTest = defaultMain $ clashTestRoot
           , buildTargets=BuildSpecific ["withSetName", "withSetNameNoResult"]
           }
         , runTest "T2549" def{hdlTargets=[Verilog],hdlSim=[]}
+        , runTest "T2781" def{hdlLoad=[],hdlSim=[],hdlTargets=[VHDL]}
         ]
       ] -- end shouldwork
     ]

--- a/hdl-tests/shouldwork/Xilinx/T2781.hs
+++ b/hdl-tests/shouldwork/Xilinx/T2781.hs
@@ -1,0 +1,35 @@
+module T2781
+  ( fullMeshSwCcTest
+  ) where
+
+import Clash.Explicit.Prelude
+import Clash.Cores.Xilinx.Ila (IlaConfig(..), Depth(..), ila, ilaConfig)
+
+fullMeshHwTestDummy ::
+  Clock System ->
+  (  Signal System Bool
+  ,  Vec 1 (Signal System Bool)
+  )
+fullMeshHwTestDummy sysClk =
+  fincFdecIla `hwSeqX`
+  ( pure False
+  , repeat (pure True)
+  )
+ where
+  fincFdecIla :: Signal System ()
+  fincFdecIla = ila
+    (ilaConfig ("trigger_0" :> Nil))
+    sysClk
+    (pure True :: Signal System Bool)
+
+-- | Top entity for this test. See module documentation for more information.
+fullMeshSwCcTest ::
+  Clock System ->
+  (Signal System Bool
+  )
+fullMeshSwCcTest sysClk = spiDone
+ where
+  (spiDone
+    , ugnsStable
+    ) = fullMeshHwTestDummy sysClk
+{-# ANN fullMeshSwCcTest (defSyn "fullMeshSwCcTest") #-}


### PR DESCRIPTION
This should have been part of PR #3 but was missed because the file name gave no indication it belonged to clash-cores.

The file was in clash-compiler but is hereby moved without change to clash-cores.

It is a regression test for
https://github.com/clash-lang/clash-compiler/issues/2781