### PR TITLE
Add `DiffClock` support to `inst`

### DIFF
--- a/src/Clash/Cores/Xilinx/Xpm/Cdc/Internal.hs
+++ b/src/Clash/Cores/Xilinx/Xpm/Cdc/Internal.hs
@@ -107,7 +107,7 @@ data Param (name :: Symbol) a = Param a
 data ClockPort (portName :: Symbol) dom = ClockPort (Clock dom)
 
 -- | Port with differential clock type, which gets 2 ports on hardware for a possitive
--- and a negative phase. The @portName@ gets the suffix '_p' and '_n' respecively
+-- and a negative phase. The @portName@ gets the suffix @_p@ and @_n@ respectively
 -- for the ports in the target HDL. For custom suffixes use 'NamedDiffClockPort'.
 data DiffClockPort (portName :: Symbol) dom = DiffClockPort (DiffClock dom)
 


### PR DESCRIPTION
`DiffClock` is only supported as an input of `inst`. There are now 2 ways to use `DiffClock` for `inst`: `DiffClockPort` gets a single symbol for the names of the ports and adds the suffixes '_p' and '_n' for the positive and negative phase respectively. `NamedDiffClockPorts` gets two symbols for the port names.