### PR TITLE
Upstream `ibufds` from bittide-hardware to clash-cores

### DIFF
--- a/clash-cores.cabal
+++ b/clash-cores.cabal
@@ -163,6 +163,7 @@ library
     Clash.Cores.Xilinx.Floating.Internal
     Clash.Cores.Xilinx.Ethernet.Gmii
     Clash.Cores.Xilinx.Ethernet.Gmii.Internal
+    Clash.Cores.Xilinx.Ibufds
     Clash.Cores.Xilinx.Ila
     Clash.Cores.Xilinx.Ila.Internal
     Clash.Cores.Xilinx.Internal

--- a/hdl-tests/Main.hs
+++ b/hdl-tests/Main.hs
@@ -182,6 +182,11 @@ runClashTest = defaultMain $ clashTestRoot
                                                       ]
                           }
           in runTest "Floating" _opts
+        , runTest "Ibufds" def
+          { hdlLoad = [Vivado]
+          , hdlSim = [Vivado]
+          , buildTargets=BuildSpecific ["testBench"]
+          }
 
 -- "Unmatchable constant as case subject"
 -- https://github.com/clash-lang/clash-compiler/issues/2806

--- a/hdl-tests/shouldwork/Xilinx/Ibufds.hs
+++ b/hdl-tests/shouldwork/Xilinx/Ibufds.hs
@@ -1,0 +1,30 @@
+module Ibufds where
+
+import Clash.Explicit.Prelude
+
+import Clash.Cores.Xilinx.Ibufds
+import Clash.Explicit.Testbench
+import Clash.Xilinx.ClockGen
+
+type Dom = XilinxSystem
+
+topEntity ::
+  DiffClock Dom ->
+  Reset Dom ->
+  Signal Dom (Index 10)
+topEntity diffClk rst = o
+ where
+  clk = ibufdsClock diffClk
+  o = register clk rst enableGen 0 $ fmap (satSucc SatBound) o
+{-# OPAQUE topEntity #-}
+
+testBench ::
+  Signal Dom Bool
+testBench = done
+ where
+  o = topEntity clkDiff rst
+  done = o .==. pure maxBound
+  clkSE = tbClockGen (not <$> done)
+  clkDiff = clockToDiffClock clkSE
+  rst = resetGen
+{-# OPAQUE testBench #-}

--- a/src/Clash/Cores/Xilinx/Ibufds.hs
+++ b/src/Clash/Cores/Xilinx/Ibufds.hs
@@ -1,0 +1,35 @@
+{-|
+  Copyright  :  (C) 2025, Google Inc,
+  License    :  BSD2 (see the file LICENSE)
+  Maintainer :  QBayLogic B.V. <devops@qbaylogic.com>
+
+Xilinx differential input buffer primitives. For more information see:
+
+https://docs.xilinx.com/r/en-US/ug974-vivado-ultrascale-libraries/IBUFDS
+-}
+module Clash.Cores.Xilinx.Ibufds where
+
+import Clash.Explicit.Prelude
+import Clash.Signal.Internal (DiffClock (..))
+
+import Clash.Cores.Xilinx.Xpm.Cdc.Internal
+
+
+{- | A differential input buffer for DiffClock. Although the @ibufds@ primitive
+can be used for any differential signal, 'ibufdsClock' is specialized for Clock.
+-}
+ibufdsClock :: forall dom. (KnownDomain dom) => DiffClock dom -> Clock dom
+ibufdsClock diffClk
+  | clashSimulation, (DiffClock clkP _clkN) <- diffClk = clkP
+  | otherwise = synth
+ where
+  synth = unPort go
+   where
+    go :: ClockPort "O" dom
+    go =
+      inst
+        (instConfig "IBUFDS")
+          { library = Just "UNISIM"
+          , libraryImport = Just "UNISIM.vcomponents.all"
+          }
+        (NamedDiffClockPort @"I" @"IB" diffClk)


### PR DESCRIPTION
Besides the hdl-test for `ibufds` I've also run a test on bittide-hardware which also synthesizes the designs and tests them on hardware (see [this job](https://github.com/bittide/bittide-hardware/actions/runs/14757050736)).