### PR TITLE
Move line codings into subdirectory

### DIFF
--- a/clash-cores.cabal
+++ b/clash-cores.cabal
@@ -146,9 +146,9 @@ library
     Clash.Cores.LatticeSemi.ECP5.IO
     Clash.Cores.LatticeSemi.ICE40.Blackboxes.IO
     Clash.Cores.LatticeSemi.ICE40.IO
-    Clash.Cores.LineCoding8b10b
-    Clash.Cores.LineCoding8b10b.Decoder
-    Clash.Cores.LineCoding8b10b.Encoder
+    Clash.Cores.LineCoding.Lc8b10b
+    Clash.Cores.LineCoding.Lc8b10b.Decoder
+    Clash.Cores.LineCoding.Lc8b10b.Encoder
     Clash.Cores.SPI
     Clash.Cores.UART
     Clash.Cores.Xilinx.BlockRam
@@ -229,7 +229,7 @@ test-suite unit-tests
     Test.Cores.Etherbone.RecordBuilder
     Test.Cores.Etherbone.RecordProcessor
     Test.Cores.Internal.SampleSPI
-    Test.Cores.LineCoding8b10b
+    Test.Cores.LineCoding.Lc8b10b
     Test.Cores.Internal.Signals
     Test.Cores.SPI
     Test.Cores.SPI.MultiSlave

--- a/src/Clash/Cores/LineCoding/Lc8b10b.hs
+++ b/src/Clash/Cores/LineCoding/Lc8b10b.hs
@@ -4,10 +4,10 @@
 --   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 --
 --   8b/10b encoding and decoding functions
-module Clash.Cores.LineCoding8b10b where
+module Clash.Cores.LineCoding.Lc8b10b where
 
-import qualified Clash.Cores.LineCoding8b10b.Decoder as Dec
-import qualified Clash.Cores.LineCoding8b10b.Encoder as Enc
+import qualified Clash.Cores.LineCoding.Lc8b10b.Decoder as Dec
+import qualified Clash.Cores.LineCoding.Lc8b10b.Encoder as Enc
 import Clash.Prelude
 
 -- | Data type that contains a 'BitVector' with the corresponding error

--- a/src/Clash/Cores/LineCoding/Lc8b10b/Decoder.hs
+++ b/src/Clash/Cores/LineCoding/Lc8b10b/Decoder.hs
@@ -5,7 +5,7 @@
 --   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 --
 --   8b/10b decoding look-up table
-module Clash.Cores.LineCoding8b10b.Decoder where
+module Clash.Cores.LineCoding.Lc8b10b.Decoder where
 
 import Clash.Prelude
 

--- a/src/Clash/Cores/LineCoding/Lc8b10b/Encoder.hs
+++ b/src/Clash/Cores/LineCoding/Lc8b10b/Encoder.hs
@@ -5,7 +5,7 @@
 --   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 --
 --   8b/10b encoding look-up table
-module Clash.Cores.LineCoding8b10b.Encoder where
+module Clash.Cores.LineCoding.Lc8b10b.Encoder where
 
 import Clash.Prelude
 

--- a/src/Clash/Cores/Sgmii.hs
+++ b/src/Clash/Cores/Sgmii.hs
@@ -62,7 +62,7 @@ module Clash.Cores.Sgmii
   )
 where
 
-import Clash.Cores.LineCoding8b10b
+import Clash.Cores.LineCoding.Lc8b10b
 import Clash.Cores.Sgmii.AutoNeg
 import Clash.Cores.Sgmii.BitSlip
 import Clash.Cores.Sgmii.Common

--- a/src/Clash/Cores/Sgmii/Common.hs
+++ b/src/Clash/Cores/Sgmii/Common.hs
@@ -8,7 +8,7 @@
 -}
 module Clash.Cores.Sgmii.Common where
 
-import Clash.Cores.LineCoding8b10b
+import Clash.Cores.LineCoding.Lc8b10b
 import Clash.Prelude
 
 -- | Format of a single code group, 10-bit

--- a/src/Clash/Cores/Sgmii/PcsReceive.hs
+++ b/src/Clash/Cores/Sgmii/PcsReceive.hs
@@ -15,7 +15,7 @@ module Clash.Cores.Sgmii.PcsReceive
   )
 where
 
-import Clash.Cores.LineCoding8b10b
+import Clash.Cores.LineCoding.Lc8b10b
 import Clash.Cores.Sgmii.Common
 import Clash.Prelude
 

--- a/src/Clash/Cores/Sgmii/PcsTransmit/CodeGroup.hs
+++ b/src/Clash/Cores/Sgmii/PcsTransmit/CodeGroup.hs
@@ -13,7 +13,7 @@ module Clash.Cores.Sgmii.PcsTransmit.CodeGroup
   )
 where
 
-import Clash.Cores.LineCoding8b10b
+import Clash.Cores.LineCoding.Lc8b10b
 import Clash.Cores.Sgmii.Common
 import Clash.Prelude
 import Data.Maybe (fromMaybe)

--- a/src/Clash/Cores/Sgmii/Sync.hs
+++ b/src/Clash/Cores/Sgmii/Sync.hs
@@ -18,7 +18,7 @@ module Clash.Cores.Sgmii.Sync
   )
 where
 
-import Clash.Cores.LineCoding8b10b
+import Clash.Cores.LineCoding.Lc8b10b
 import Clash.Cores.Sgmii.Common
 import Clash.Prelude
 import Data.Maybe (isNothing)

--- a/test/Test/Cores/LineCoding/Lc8b10b.hs
+++ b/test/Test/Cores/LineCoding/Lc8b10b.hs
@@ -4,9 +4,9 @@
 --   Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 --
 --   8b/10b encoding and decoding tests
-module Test.Cores.LineCoding8b10b where
+module Test.Cores.LineCoding.Lc8b10b where
 
-import Clash.Cores.LineCoding8b10b
+import Clash.Cores.LineCoding.Lc8b10b
 import Clash.Hedgehog.Sized.BitVector
 import qualified Clash.Prelude as C
 import Control.Monad (when)

--- a/test/Test/Cores/Sgmii/BitSlip.hs
+++ b/test/Test/Cores/Sgmii/BitSlip.hs
@@ -9,7 +9,7 @@ import Data.Maybe (isJust, isNothing)
 import qualified Hedgehog as H
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import Test.Cores.LineCoding8b10b
+import Test.Cores.LineCoding.Lc8b10b
 import Test.Tasty
 import Test.Tasty.Hedgehog
 import Test.Tasty.TH

--- a/test/Test/Cores/Sgmii/Sync.hs
+++ b/test/Test/Cores/Sgmii/Sync.hs
@@ -1,6 +1,6 @@
 module Test.Cores.Sgmii.Sync where
 
-import Clash.Cores.LineCoding8b10b
+import Clash.Cores.LineCoding.Lc8b10b
 import Clash.Cores.Sgmii.Common
 import Clash.Cores.Sgmii.Sync
 import Clash.Hedgehog.Sized.BitVector
@@ -10,7 +10,7 @@ import Data.List (group, mapAccumL, maximumBy)
 import qualified Hedgehog as H
 import qualified Hedgehog.Gen as Gen
 import qualified Hedgehog.Range as Range
-import Test.Cores.LineCoding8b10b
+import Test.Cores.LineCoding.Lc8b10b
 import Test.Tasty
 import Test.Tasty.Hedgehog
 import Test.Tasty.TH

--- a/test/unit-tests.hs
+++ b/test/unit-tests.hs
@@ -15,7 +15,7 @@ import Test.Tasty
 
 import qualified Test.Cores.Crc
 import qualified Test.Cores.Etherbone
-import qualified Test.Cores.LineCoding8b10b
+import qualified Test.Cores.LineCoding.Lc8b10b
 #if MIN_VERSION_clash_prelude(1,9,0)
 import qualified Test.Cores.Sgmii.AutoNeg
 import qualified Test.Cores.Sgmii.BitSlip
@@ -35,7 +35,7 @@ tests :: TestTree
 tests = testGroup "Unittests" $
   [ Test.Cores.Crc.tests
   , Test.Cores.Etherbone.tests
-  , Test.Cores.LineCoding8b10b.tests
+  , Test.Cores.LineCoding.Lc8b10b.tests
   , Test.Cores.SPI.tests
   , Test.Cores.SPI.MultiSlave.tests
   , Test.Cores.UART.tests


### PR DESCRIPTION
I'd like to revisit the 8b10b line coding to hopefully resolve https://github.com/clash-lang/clash-compiler/issues/2755 and https://github.com/clash-lang/clash-compiler/issues/2756. As a starting point I think it makes sense to move the line codings into a subdirectory, because potentially having multiple line codings in the top directory (say `LineCoding3b4b`, `LineCoding5b6b`, which I might want to implement to improve 8b10b) clutters everything.