### PR TITLE
Fix bug with wrong order of type application in `genDefinedBitVector`

### DIFF
--- a/test/Test/Cores/Xilinx/DcFifo.hs
+++ b/test/Test/Cores/Xilinx/DcFifo.hs
@@ -402,7 +402,8 @@ prop_dcFifoDf =
     model
     impl
  where
-  gen = Gen.list (Range.linear 0 100) (genDefinedBitVector @_ @32)
+  gen :: Gen [BitVector 32]
+  gen = Gen.list (Range.linear 0 100) genDefinedBitVector
   model = id
   impl = dcFifoDf d4 wClk wRst rClk rRst
   (wClk, wRst) = (clockGen @D3, resetGen)


### PR DESCRIPTION
PR #39 was accidentally auto-merged, so this new PR is a quick fixup.