### PR TITLE
Replace `linuwial-wrap-types.css` symlink with file

### DIFF
--- a/doc/linuwial-wrap-types.css
+++ b/doc/linuwial-wrap-types.css
@@ -1,1 +1,6 @@
-../../clash-prelude/doc/linuwial-wrap-types.css
+@import "linuwial.css";
+
+/* Re-enable wordwrapping in (parts of) type signatures */
+#interface td.src {
+  white-space: normal !important;
+}


### PR DESCRIPTION
Before the migration from `clash-lang/clash-compiler`, `linuwial-wrap-types.css` would be a symlink to `/clash-prelude/doc/linuwial-wrap-types.css` When we migrated this to its own repo we broke this symlink so I replaced it with the file itself.