### PR TITLE
Updates README to include link to Adam Walker's clash utils/circuits

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ This code was originally a sub-folder within the clash-compiler repo, but now it
 
 If you're looking for a pre-built Clash circuit and don't find it here, you can also check out [Clash Protocols](https://github.com/clash-lang/clash-protocols/tree/main/clash-protocols/src/Protocols) to see if it exists there.
 
-You can also look through Adam Walker's excellent list of [prebuilt Clash circuits](https://github.com/adamwalker/clash-utils).
+You can also look through Adam Walker's excellent list of [prebuilt Clash circuits](https://github.com/adamwalker/clash-utils) and other community projects on Clash's [ecosystem page](https://clash-lang.org/ecosystem/).

--- a/README.md
+++ b/README.md
@@ -18,3 +18,4 @@ This code was originally a sub-folder within the clash-compiler repo, but now it
 
 If you're looking for a pre-built Clash circuit and don't find it here, you can also check out [Clash Protocols](https://github.com/clash-lang/clash-protocols/tree/main/clash-protocols/src/Protocols) to see if it exists there.
 
+You can also look through Adam Walker's excellent list of [prebuilt Clash circuits](https://github.com/adamwalker/clash-utils).


### PR DESCRIPTION
Adding a link to Adam Walker's Clash utils. There are enough useful circuits in the repo not covered in Clash.Cores and the repo gets buried enough in searches that I think it'd be good to directly link to it.

The one hesitation I have is the circuits might not work with newer versions of Clash. There's an open PR that adds support for Clash 1.8.2/GHC 9.6.7 - looking at the diff, it's only version bumps, which is promising from a compatibility point of view.

We could add a disclaimer that it has not been tested against newer versions of Clash if desired.

Thoughts?