### PR TITLE
Project Nix Flakes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,306 @@
+{
+  "nodes": {
+    "circuit-notation": {
+      "inputs": {
+        "clash-compiler": [
+          "clash-protocols",
+          "clash-compiler"
+        ],
+        "flake-utils": "flake-utils_2"
+      },
+      "locked": {
+        "lastModified": 1753788891,
+        "narHash": "sha256-UcrvegnJUr0iIuR1nK9gmWufx+lfVhbdVnA7tF9YiSY=",
+        "owner": "cchalmers",
+        "repo": "circuit-notation",
+        "rev": "68484f9837b9915ac5b340aeafeda3f8c0c4d3fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cchalmers",
+        "repo": "circuit-notation",
+        "type": "github"
+      }
+    },
+    "clash-compiler": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "ghc-tcplugins-extra": "ghc-tcplugins-extra",
+        "ghc-typelits-extra": "ghc-typelits-extra",
+        "ghc-typelits-knownnat": "ghc-typelits-knownnat",
+        "ghc-typelits-natnormalise": "ghc-typelits-natnormalise",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1753722205,
+        "narHash": "sha256-tfBkzRbiYVX6f0oSnY86Uem/JSsCmYXfAJxW+ZKmWQk=",
+        "owner": "clash-lang",
+        "repo": "clash-compiler",
+        "rev": "43a1c722af29f34c6faf18f14e6cf46a3cfba80f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "clash-lang",
+        "repo": "clash-compiler",
+        "type": "github"
+      }
+    },
+    "clash-protocols": {
+      "inputs": {
+        "circuit-notation": "circuit-notation",
+        "clash-compiler": [
+          "clash-compiler"
+        ],
+        "flake-utils": "flake-utils_3"
+      },
+      "locked": {
+        "lastModified": 1753793461,
+        "narHash": "sha256-X6q8naDK7SufBaE0DrvSMyQTOynNNxuRN0JMkGsXeLQ=",
+        "owner": "clash-lang",
+        "repo": "clash-protocols",
+        "rev": "d4f1c73ad71fe78210b9fde882cb7744197031e6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "clash-lang",
+        "repo": "clash-protocols",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "flake-utils_3": {
+      "inputs": {
+        "systems": "systems_3"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "flake-utils_4": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "ghc-tcplugins-extra": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1716385093,
+        "narHash": "sha256-pXQoPP22TicWFwpWub9CX1J+rpOKfyX2IyzlCg1qG84=",
+        "owner": "clash-lang",
+        "repo": "ghc-tcplugins-extra",
+        "rev": "702dda2095c66c4f5148a749c8b7dbcc8a09f5c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "clash-lang",
+        "repo": "ghc-tcplugins-extra",
+        "type": "github"
+      }
+    },
+    "ghc-typelits-extra": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1716411282,
+        "narHash": "sha256-YH03Ce+TEWKHGAm7BhynitZomfpYeKpqvZAviw8yEPA=",
+        "owner": "clash-lang",
+        "repo": "ghc-typelits-extra",
+        "rev": "4dadc824a3ef9a511fcf6605167715a5a655ba0d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "clash-lang",
+        "repo": "ghc-typelits-extra",
+        "type": "github"
+      }
+    },
+    "ghc-typelits-knownnat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1716408841,
+        "narHash": "sha256-A2v6GkMtSJqZXpTwWfIcwshieyRySeR1bP+NogUHNoo=",
+        "owner": "clash-lang",
+        "repo": "ghc-typelits-knownnat",
+        "rev": "2e57de3b709dab085fb1657cf73d4f5e833229ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "clash-lang",
+        "repo": "ghc-typelits-knownnat",
+        "type": "github"
+      }
+    },
+    "ghc-typelits-natnormalise": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1716387676,
+        "narHash": "sha256-G5p0NUy4CpjxGO1VNhb38fhkXESFPxGaZJM0qd6L74U=",
+        "owner": "clash-lang",
+        "repo": "ghc-typelits-natnormalise",
+        "rev": "84f500a9735675e96253181939c3473a567f6f7a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "clash-lang",
+        "repo": "ghc-typelits-natnormalise",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1727089097,
+        "narHash": "sha256-ZMHMThPsthhUREwDebXw7GX45bJnBCVbfnH1g5iuSPc=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "568bfef547c14ca438c56a0bece08b8bb2b71a9c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "clash-compiler": "clash-compiler",
+        "clash-protocols": "clash-protocols",
+        "flake-utils": "flake-utils_4"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,71 @@
+{
+  description = "A flake for developing & using clash-cores";
+  inputs = {
+    clash-compiler.url = "github:clash-lang/clash-compiler";
+    clash-protocols = {
+      url = "github:clash-lang/clash-protocols";
+      inputs.clash-compiler.follows = "clash-compiler";
+    };
+  };
+  outputs = { self, flake-utils, clash-compiler, clash-protocols, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        # What version of the GHC compiler to use for protocols
+        compiler-version = clash-compiler.ghcVersion.${system};
+
+        pkgs = (import clash-compiler.inputs.nixpkgs {
+          inherit system;
+        }).extend clash-compiler.overlays.${compiler-version};
+        clash-pkgs = pkgs."clashPackages-${compiler-version}";
+
+        overlay = final: prev: {
+          clash-cores = prev.developPackage {
+            root = ./.;
+            overrides = _: _: final;
+          };
+        }
+        # Make sure clash-protocols is in scope as well
+        // (clash-protocols.overlays.${system}.default final prev);
+        hs-pkgs = clash-pkgs.extend overlay;
+      in
+      {
+        # Expose the overlay which adds clash-cores
+        # (...along the inherited overlays)
+        # The base of the overlay is clash-pkgs
+        overlays.default = overlay;
+
+        devShells = rec {
+          minimal = hs-pkgs.shellFor {
+            packages = p: [
+              p.clash-cores
+            ];
+
+            nativeBuildInputs = [
+              hs-pkgs.cabal-install
+            ];
+          };
+
+          full = hs-pkgs.shellFor {
+            packages = p: [
+              p.clash-cores
+            ];
+
+            nativeBuildInputs =
+              [
+                hs-pkgs.cabal-install
+                hs-pkgs.haskell-language-server
+                hs-pkgs.fourmolu
+              ]
+            ;
+          };
+
+          default = minimal;
+        };
+
+        packages = {
+          clash-cores = hs-pkgs.clash-cores;
+
+          default = hs-pkgs.clash-cores;
+        };
+      });
+}


### PR DESCRIPTION
Introduces a Nix flake for clash-cores, making it easy to include clash-cores in projects. Aside from clash-cores itself, it also exposes an overlay which makes it easy to add clash-cores to your local project flake without getting weird version conflicts.

### ~~THIS REQUIRES A PR IN PROTOCOLS TO BE MERGED FIRST!~~
~~https://github.com/clash-lang/clash-protocols/pull/162~~