### PR TITLE
Add 5b/6b line coding

### DIFF
--- a/clash-cores.cabal
+++ b/clash-cores.cabal
@@ -146,6 +146,9 @@ library
     Clash.Cores.LatticeSemi.ECP5.IO
     Clash.Cores.LatticeSemi.ICE40.Blackboxes.IO
     Clash.Cores.LatticeSemi.ICE40.IO
+    Clash.Cores.LineCoding.Lc5b6b
+    Clash.Cores.LineCoding.Lc5b6b.Decoder
+    Clash.Cores.LineCoding.Lc5b6b.Encoder
     Clash.Cores.LineCoding.Lc8b10b
     Clash.Cores.LineCoding.Lc8b10b.Decoder
     Clash.Cores.LineCoding.Lc8b10b.Encoder

--- a/clash-cores.cabal
+++ b/clash-cores.cabal
@@ -232,6 +232,7 @@ test-suite unit-tests
     Test.Cores.Etherbone.RecordBuilder
     Test.Cores.Etherbone.RecordProcessor
     Test.Cores.Internal.SampleSPI
+    Test.Cores.LineCoding.Lc5b6b
     Test.Cores.LineCoding.Lc8b10b
     Test.Cores.Internal.Signals
     Test.Cores.SPI

--- a/src/Clash/Cores/LineCoding/Lc5b6b.hs
+++ b/src/Clash/Cores/LineCoding/Lc5b6b.hs
@@ -1,0 +1,8 @@
+{- |
+  Copyright   :  (C) 2025, Jasper Vinkenvleugel <j.t.vinkenvleugel@proton.me>
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+
+  5b/6b encoding and decoding functions
+-}
+module Clash.Cores.LineCoding.Lc5b6b where

--- a/src/Clash/Cores/LineCoding/Lc5b6b.hs
+++ b/src/Clash/Cores/LineCoding/Lc5b6b.hs
@@ -6,3 +6,24 @@
   5b/6b encoding and decoding functions
 -}
 module Clash.Cores.LineCoding.Lc5b6b where
+
+import Clash.Prelude
+
+import qualified Clash.Cores.LineCoding.Lc5b6b.Decoder as Dec
+import qualified Clash.Cores.LineCoding.Lc5b6b.Encoder as Enc
+
+decode5b6b ::
+  Bool ->
+  BitVector 6 ->
+  Maybe (Bool, BitVector 5)
+decode5b6b rd cg = case $(listToVecTH Dec.decoderLut) !! (pack rd ++# cg) of
+  Just (rdChange, bv) -> Just (if rdChange then not rd else rd, bv)
+  Nothing -> Nothing
+{-# OPAQUE decode5b6b #-}
+
+encode5b6b ::
+  Bool ->
+  BitVector 5 ->
+  Maybe (Bool, BitVector 6)
+encode5b6b rd bv = $(listToVecTH Enc.encoderLut) !! (pack rd ++# bv)
+{-# OPAQUE encode5b6b #-}

--- a/src/Clash/Cores/LineCoding/Lc5b6b/Decoder.hs
+++ b/src/Clash/Cores/LineCoding/Lc5b6b/Decoder.hs
@@ -1,0 +1,13 @@
+{- |
+  Copyright   :  (C) 2025, Jasper Vinkenvleugel <j.t.vinkenvleugel@proton.me>
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+
+  5b/6b decoding look-up table
+-}
+module Clash.Cores.LineCoding.Lc5b6b.Decoder where
+
+import Clash.Prelude
+
+decoderLut :: [Maybe (Bit, BitVector 5)]
+decoderLut = undefined

--- a/src/Clash/Cores/LineCoding/Lc5b6b/Decoder.hs
+++ b/src/Clash/Cores/LineCoding/Lc5b6b/Decoder.hs
@@ -1,13 +1,85 @@
 {- |
-  Copyright   :  (C) 2025, Jasper Vinkenvleugel <j.t.vinkenvleugel@proton.me>
-  License     :  BSD2 (see the file LICENSE)
-  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+ Copyright   :  (C) 2025, Jasper Vinkenvleugel <j.t.vinkenvleugel@proton.me>
+ License     :  BSD2 (see the file LICENSE)
+ Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
 
-  5b/6b decoding look-up table
+ 5b/6b decoding look-up table
 -}
 module Clash.Cores.LineCoding.Lc5b6b.Decoder where
 
 import Clash.Prelude
+import qualified Clash.Sized.Internal.BitVector as BV
+import qualified Prelude as P
 
-decoderLut :: [Maybe (Bit, BitVector 5)]
-decoderLut = undefined
+decoderLut :: [Maybe (Bool, BitVector 5)]
+decoderLut = P.map ((`P.lookup` decoderLutList) P.. unpack . BV.toEnum#) [0 .. 127]
+
+decoderLutList :: [((Bool, BitVector 6), (Bool, BitVector 5))]
+decoderLutList =
+  [ ((False, 0b100111), (True, 0b00000)) -- D.00
+  , ((True, 0b011000), (True, 0b00000)) -- D.00
+  , ((False, 0b011101), (True, 0b00001)) -- D.01
+  , ((True, 0b100010), (True, 0b00001)) -- D.01
+  , ((False, 0b101101), (True, 0b00010)) -- D.02
+  , ((True, 0b010010), (True, 0b00010)) -- D.02
+  , ((False, 0b110001), (False, 0b00011)) -- D.03
+  , ((True, 0b110001), (False, 0b00011)) -- D.03
+  , ((False, 0b110101), (True, 0b00100)) -- D.04
+  , ((True, 0b001010), (True, 0b00100)) -- D.04
+  , ((False, 0b101001), (False, 0b00101)) -- D.05
+  , ((True, 0b101001), (False, 0b00101)) -- D.05
+  , ((False, 0b011001), (False, 0b00110)) -- D.06
+  , ((True, 0b011001), (False, 0b00110)) -- D.06
+  , ((False, 0b111000), (True, 0b00111)) -- D.07
+  , ((True, 0b000111), (True, 0b00111)) -- D.07
+  , ((False, 0b111001), (True, 0b01000)) -- D.08
+  , ((True, 0b000110), (True, 0b01000)) -- D.08
+  , ((False, 0b100101), (False, 0b01001)) -- D.09
+  , ((True, 0b100101), (False, 0b01001)) -- D.09
+  , ((False, 0b010101), (False, 0b01010)) -- D.10
+  , ((True, 0b010101), (False, 0b01010)) -- D.10
+  , ((False, 0b110100), (False, 0b01011)) -- D.11
+  , ((True, 0b110100), (False, 0b01011)) -- D.11
+  , ((False, 0b001101), (False, 0b01100)) -- D.12
+  , ((True, 0b001101), (False, 0b01100)) -- D.12
+  , ((False, 0b101100), (False, 0b01101)) -- D.13
+  , ((True, 0b101100), (False, 0b01101)) -- D.13
+  , ((False, 0b011100), (False, 0b01110)) -- D.14
+  , ((True, 0b011100), (False, 0b01110)) -- D.14
+  , ((False, 0b010111), (True, 0b01111)) -- D.15
+  , ((True, 0b101000), (True, 0b01111)) -- D.15
+  , ((False, 0b011011), (True, 0b10000)) -- D.16
+  , ((True, 0b100100), (True, 0b10000)) -- D.16
+  , ((False, 0b100011), (False, 0b10001)) -- D.17
+  , ((True, 0b100011), (False, 0b10001)) -- D.17
+  , ((False, 0b010011), (False, 0b10010)) -- D.18
+  , ((True, 0b010011), (False, 0b10010)) -- D.18
+  , ((False, 0b110010), (False, 0b10011)) -- D.19
+  , ((True, 0b110010), (False, 0b10011)) -- D.19
+  , ((False, 0b001011), (False, 0b10100)) -- D.20
+  , ((True, 0b001011), (False, 0b10100)) -- D.20
+  , ((False, 0b101010), (False, 0b10101)) -- D.21
+  , ((True, 0b101010), (False, 0b10101)) -- D.21
+  , ((False, 0b011010), (False, 0b10110)) -- D.22
+  , ((True, 0b011010), (False, 0b10110)) -- D.22
+  , ((False, 0b111010), (True, 0b10111)) -- D.23, K.23
+  , ((True, 0b000101), (True, 0b10111)) -- D.23, K.23
+  , ((False, 0b110011), (True, 0b11000)) -- D.24
+  , ((True, 0b001100), (True, 0b11000)) -- D.24
+  , ((False, 0b100110), (False, 0b11001)) -- D.25
+  , ((True, 0b100110), (False, 0b11001)) -- D.25
+  , ((False, 0b010110), (False, 0b11010)) -- D.26
+  , ((True, 0b010110), (False, 0b11010)) -- D.26
+  , ((False, 0b110110), (True, 0b11011)) -- D.27, K.27
+  , ((True, 0b001001), (True, 0b11011)) -- D.27, K.27
+  , ((False, 0b001110), (False, 0b11100)) -- D.28
+  , ((True, 0b001110), (False, 0b11100)) -- D.28
+  , ((False, 0b101110), (True, 0b11101)) -- D.29, K.29
+  , ((True, 0b010001), (True, 0b11101)) -- D.29, K.29
+  , ((False, 0b011110), (True, 0b11110)) -- D.30, K.30
+  , ((True, 0b100001), (True, 0b11110)) -- D.30, K.30
+  , ((False, 0b101011), (True, 0b11111)) -- D.31
+  , ((True, 0b010100), (True, 0b11111)) -- D.31
+  , ((False, 0b001111), (True, 0b11100)) -- K.28
+  , ((True, 0b110000), (True, 0b11100)) -- K.28
+  ]

--- a/src/Clash/Cores/LineCoding/Lc5b6b/Encoder.hs
+++ b/src/Clash/Cores/LineCoding/Lc5b6b/Encoder.hs
@@ -9,72 +9,72 @@ module Clash.Cores.LineCoding.Lc5b6b.Encoder where
 
 import Clash.Prelude
 
-encoderLut :: [Maybe (Bit, BitVector 6)]
+encoderLut :: [Maybe (Bool, BitVector 6)]
 encoderLut =
-  [ Just (1, 0b100111) -- D.00
-  , Just (1, 0b011101) -- D.01
-  , Just (1, 0b101101) -- D.02
-  , Just (0, 0b110001) -- D.03
-  , Just (1, 0b110101) -- D.04
-  , Just (0, 0b101001) -- D.05
-  , Just (0, 0b011001) -- D.06
-  , Just (1, 0b111000) -- D.07
-  , Just (1, 0b111001) -- D.08
-  , Just (0, 0b100101) -- D.09
-  , Just (0, 0b010101) -- D.10
-  , Just (0, 0b110100) -- D.11
-  , Just (0, 0b001101) -- D.12
-  , Just (0, 0b101100) -- D.13
-  , Just (0, 0b011100) -- D.14
-  , Just (1, 0b010111) -- D.15
-  , Just (1, 0b011011) -- D.16
-  , Just (0, 0b100011) -- D.17
-  , Just (0, 0b010011) -- D.18
-  , Just (0, 0b110010) -- D.19
-  , Just (0, 0b001011) -- D.20
-  , Just (0, 0b101010) -- D.21
-  , Just (0, 0b011010) -- D.22
-  , Just (1, 0b111010) -- D.23
-  , Just (1, 0b110011) -- D.24
-  , Just (0, 0b100110) -- D.25
-  , Just (0, 0b010110) -- D.26
-  , Just (1, 0b110110) -- D.27
-  , Just (0, 0b001110) -- D.28
-  , Just (1, 0b101110) -- D.29
-  , Just (1, 0b011110) -- D.30
-  , Just (1, 0b101011) -- D.31
-  , Just (0, 0b011000) -- D.00
-  , Just (0, 0b100010) -- D.01
-  , Just (0, 0b010010) -- D.02
-  , Just (1, 0b110001) -- D.03
-  , Just (0, 0b001010) -- D.04
-  , Just (1, 0b101001) -- D.05
-  , Just (1, 0b011001) -- D.06
-  , Just (0, 0b000111) -- D.07
-  , Just (0, 0b000110) -- D.08
-  , Just (1, 0b100101) -- D.09
-  , Just (1, 0b010101) -- D.10
-  , Just (1, 0b110100) -- D.11
-  , Just (1, 0b001101) -- D.12
-  , Just (1, 0b101100) -- D.13
-  , Just (1, 0b011100) -- D.14
-  , Just (0, 0b101000) -- D.15
-  , Just (0, 0b100100) -- D.16
-  , Just (1, 0b100011) -- D.17
-  , Just (1, 0b010011) -- D.18
-  , Just (1, 0b110010) -- D.19
-  , Just (1, 0b001011) -- D.20
-  , Just (1, 0b101010) -- D.21
-  , Just (1, 0b011010) -- D.22
-  , Just (0, 0b000101) -- D.23
-  , Just (0, 0b001100) -- D.24
-  , Just (1, 0b100110) -- D.25
-  , Just (1, 0b010110) -- D.26
-  , Just (0, 0b001001) -- D.27
-  , Just (1, 0b001110) -- D.28
-  , Just (0, 0b010001) -- D.29
-  , Just (0, 0b100001) -- D.30
-  , Just (0, 0b010100) -- D.31
+  [ Just (True, 0b100111) -- D.00
+  , Just (True, 0b011101) -- D.01
+  , Just (True, 0b101101) -- D.02
+  , Just (False, 0b110001) -- D.03
+  , Just (True, 0b110101) -- D.04
+  , Just (False, 0b101001) -- D.05
+  , Just (False, 0b011001) -- D.06
+  , Just (True, 0b111000) -- D.07
+  , Just (True, 0b111001) -- D.08
+  , Just (False, 0b100101) -- D.09
+  , Just (False, 0b010101) -- D.10
+  , Just (False, 0b110100) -- D.11
+  , Just (False, 0b001101) -- D.12
+  , Just (False, 0b101100) -- D.13
+  , Just (False, 0b011100) -- D.14
+  , Just (True, 0b010111) -- D.15
+  , Just (True, 0b011011) -- D.16
+  , Just (False, 0b100011) -- D.17
+  , Just (False, 0b010011) -- D.18
+  , Just (False, 0b110010) -- D.19
+  , Just (False, 0b001011) -- D.20
+  , Just (False, 0b101010) -- D.21
+  , Just (False, 0b011010) -- D.22
+  , Just (True, 0b111010) -- D.23
+  , Just (True, 0b110011) -- D.24
+  , Just (False, 0b100110) -- D.25
+  , Just (False, 0b010110) -- D.26
+  , Just (True, 0b110110) -- D.27
+  , Just (False, 0b001110) -- D.28
+  , Just (True, 0b101110) -- D.29
+  , Just (True, 0b011110) -- D.30
+  , Just (True, 0b101011) -- D.31
+  , Just (False, 0b011000) -- D.00
+  , Just (False, 0b100010) -- D.01
+  , Just (False, 0b010010) -- D.02
+  , Just (True, 0b110001) -- D.03
+  , Just (False, 0b001010) -- D.04
+  , Just (True, 0b101001) -- D.05
+  , Just (True, 0b011001) -- D.06
+  , Just (False, 0b000111) -- D.07
+  , Just (False, 0b000110) -- D.08
+  , Just (True, 0b100101) -- D.09
+  , Just (True, 0b010101) -- D.10
+  , Just (True, 0b110100) -- D.11
+  , Just (True, 0b001101) -- D.12
+  , Just (True, 0b101100) -- D.13
+  , Just (True, 0b011100) -- D.14
+  , Just (False, 0b101000) -- D.15
+  , Just (False, 0b100100) -- D.16
+  , Just (True, 0b100011) -- D.17
+  , Just (True, 0b010011) -- D.18
+  , Just (True, 0b110010) -- D.19
+  , Just (True, 0b001011) -- D.20
+  , Just (True, 0b101010) -- D.21
+  , Just (True, 0b011010) -- D.22
+  , Just (False, 0b000101) -- D.23
+  , Just (False, 0b001100) -- D.24
+  , Just (True, 0b100110) -- D.25
+  , Just (True, 0b010110) -- D.26
+  , Just (False, 0b001001) -- D.27
+  , Just (True, 0b001110) -- D.28
+  , Just (False, 0b010001) -- D.29
+  , Just (False, 0b100001) -- D.30
+  , Just (False, 0b010100) -- D.31
   , Nothing -- K.00
   , Nothing -- K.01
   , Nothing -- K.02
@@ -98,14 +98,14 @@ encoderLut =
   , Nothing -- K.20
   , Nothing -- K.21
   , Nothing -- K.22
-  , Just (1, 0b111010) -- K.23
+  , Just (True, 0b111010) -- K.23
   , Nothing -- K.24
   , Nothing -- K.25
   , Nothing -- K.26
-  , Just (1, 0b110110) -- K.27
-  , Just (1, 0b001111) -- K.28
-  , Just (1, 0b101110) -- K.29
-  , Just (1, 0b011110) -- K.30
+  , Just (True, 0b110110) -- K.27
+  , Just (True, 0b001111) -- K.28
+  , Just (True, 0b101110) -- K.29
+  , Just (True, 0b011110) -- K.30
   , Nothing -- K.31
   , Nothing -- K.00
   , Nothing -- K.01
@@ -130,13 +130,13 @@ encoderLut =
   , Nothing -- K.20
   , Nothing -- K.21
   , Nothing -- K.22
-  , Just (0, 0b000101) -- K.23
+  , Just (False, 0b000101) -- K.23
   , Nothing -- K.24
   , Nothing -- K.25
   , Nothing -- K.26
-  , Just (0, 0b001001) -- K.27
-  , Just (0, 0b110000) -- K.28
-  , Just (0, 0b010001) -- K.29
-  , Just (0, 0b100001) -- K.30
+  , Just (False, 0b001001) -- K.27
+  , Just (False, 0b110000) -- K.28
+  , Just (False, 0b010001) -- K.29
+  , Just (False, 0b100001) -- K.30
   , Nothing -- K.31
   ]

--- a/src/Clash/Cores/LineCoding/Lc5b6b/Encoder.hs
+++ b/src/Clash/Cores/LineCoding/Lc5b6b/Encoder.hs
@@ -1,0 +1,142 @@
+{- |
+  Copyright   :  (C) 2025, Jasper Vinkenvleugel <j.t.vinkenvleugel@proton.me>
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+
+  5b/6b encoding look-up table
+-}
+module Clash.Cores.LineCoding.Lc5b6b.Encoder where
+
+import Clash.Prelude
+
+encoderLut :: [Maybe (Bit, BitVector 6)]
+encoderLut =
+  [ Just (1, 0b100111) -- D.00
+  , Just (1, 0b011101) -- D.01
+  , Just (1, 0b101101) -- D.02
+  , Just (0, 0b110001) -- D.03
+  , Just (1, 0b110101) -- D.04
+  , Just (0, 0b101001) -- D.05
+  , Just (0, 0b011001) -- D.06
+  , Just (1, 0b111000) -- D.07
+  , Just (1, 0b111001) -- D.08
+  , Just (0, 0b100101) -- D.09
+  , Just (0, 0b010101) -- D.10
+  , Just (0, 0b110100) -- D.11
+  , Just (0, 0b001101) -- D.12
+  , Just (0, 0b101100) -- D.13
+  , Just (0, 0b011100) -- D.14
+  , Just (1, 0b010111) -- D.15
+  , Just (1, 0b011011) -- D.16
+  , Just (0, 0b100011) -- D.17
+  , Just (0, 0b010011) -- D.18
+  , Just (0, 0b110010) -- D.19
+  , Just (0, 0b001011) -- D.20
+  , Just (0, 0b101010) -- D.21
+  , Just (0, 0b011010) -- D.22
+  , Just (1, 0b111010) -- D.23
+  , Just (1, 0b110011) -- D.24
+  , Just (0, 0b100110) -- D.25
+  , Just (0, 0b010110) -- D.26
+  , Just (1, 0b110110) -- D.27
+  , Just (0, 0b001110) -- D.28
+  , Just (1, 0b101110) -- D.29
+  , Just (1, 0b011110) -- D.30
+  , Just (1, 0b101011) -- D.31
+  , Just (0, 0b011000) -- D.00
+  , Just (0, 0b100010) -- D.01
+  , Just (0, 0b010010) -- D.02
+  , Just (1, 0b110001) -- D.03
+  , Just (0, 0b001010) -- D.04
+  , Just (1, 0b101001) -- D.05
+  , Just (1, 0b011001) -- D.06
+  , Just (0, 0b000111) -- D.07
+  , Just (0, 0b000110) -- D.08
+  , Just (1, 0b100101) -- D.09
+  , Just (1, 0b010101) -- D.10
+  , Just (1, 0b110100) -- D.11
+  , Just (1, 0b001101) -- D.12
+  , Just (1, 0b101100) -- D.13
+  , Just (1, 0b011100) -- D.14
+  , Just (0, 0b101000) -- D.15
+  , Just (0, 0b100100) -- D.16
+  , Just (1, 0b100011) -- D.17
+  , Just (1, 0b010011) -- D.18
+  , Just (1, 0b110010) -- D.19
+  , Just (1, 0b001011) -- D.20
+  , Just (1, 0b101010) -- D.21
+  , Just (1, 0b011010) -- D.22
+  , Just (0, 0b000101) -- D.23
+  , Just (0, 0b001100) -- D.24
+  , Just (1, 0b100110) -- D.25
+  , Just (1, 0b010110) -- D.26
+  , Just (0, 0b001001) -- D.27
+  , Just (1, 0b001110) -- D.28
+  , Just (0, 0b010001) -- D.29
+  , Just (0, 0b100001) -- D.30
+  , Just (0, 0b010100) -- D.31
+  , Nothing -- K.00
+  , Nothing -- K.01
+  , Nothing -- K.02
+  , Nothing -- K.03
+  , Nothing -- K.04
+  , Nothing -- K.05
+  , Nothing -- K.06
+  , Nothing -- K.07
+  , Nothing -- K.08
+  , Nothing -- K.09
+  , Nothing -- K.10
+  , Nothing -- K.11
+  , Nothing -- K.12
+  , Nothing -- K.13
+  , Nothing -- K.14
+  , Nothing -- K.15
+  , Nothing -- K.16
+  , Nothing -- K.17
+  , Nothing -- K.18
+  , Nothing -- K.19
+  , Nothing -- K.20
+  , Nothing -- K.21
+  , Nothing -- K.22
+  , Just (1, 0b111010) -- K.23
+  , Nothing -- K.24
+  , Nothing -- K.25
+  , Nothing -- K.26
+  , Just (1, 0b110110) -- K.27
+  , Just (1, 0b001111) -- K.28
+  , Just (1, 0b101110) -- K.29
+  , Just (1, 0b011110) -- K.30
+  , Nothing -- K.31
+  , Nothing -- K.00
+  , Nothing -- K.01
+  , Nothing -- K.02
+  , Nothing -- K.03
+  , Nothing -- K.04
+  , Nothing -- K.05
+  , Nothing -- K.06
+  , Nothing -- K.07
+  , Nothing -- K.08
+  , Nothing -- K.09
+  , Nothing -- K.10
+  , Nothing -- K.11
+  , Nothing -- K.12
+  , Nothing -- K.13
+  , Nothing -- K.14
+  , Nothing -- K.15
+  , Nothing -- K.16
+  , Nothing -- K.17
+  , Nothing -- K.18
+  , Nothing -- K.19
+  , Nothing -- K.20
+  , Nothing -- K.21
+  , Nothing -- K.22
+  , Just (0, 0b000101) -- K.23
+  , Nothing -- K.24
+  , Nothing -- K.25
+  , Nothing -- K.26
+  , Just (0, 0b001001) -- K.27
+  , Just (0, 0b110000) -- K.28
+  , Just (0, 0b010001) -- K.29
+  , Just (0, 0b100001) -- K.30
+  , Nothing -- K.31
+  ]

--- a/test/Test/Cores/LineCoding/Lc5b6b.hs
+++ b/test/Test/Cores/LineCoding/Lc5b6b.hs
@@ -1,0 +1,29 @@
+{- |
+  Copyright   :  (C) 2024, QBayLogic B.V.
+  License     :  BSD2 (see the file LICENSE)
+  Maintainer  :  QBayLogic B.V. <devops@qbaylogic.com>
+
+  5b/6b encoding and decoding tests
+-}
+module Test.Cores.LineCoding.Lc5b6b where
+
+import Clash.Cores.LineCoding.Lc5b6b
+import Clash.Hedgehog.Sized.BitVector
+import Data.Maybe (fromJust)
+import qualified Hedgehog as H
+import Test.Tasty
+import Test.Tasty.Hedgehog
+import Test.Tasty.TH
+import Prelude
+
+prop_encodeDecode5b6b :: H.Property
+prop_encodeDecode5b6b = H.withTests 1000 $ H.property $ do
+  inp <- H.forAll genDefinedBitVector
+  roundTrip False inp H.=== inp
+  roundTrip True inp H.=== inp
+ where
+  roundTrip rd inp =
+    snd $ fromJust $ decode5b6b rd $ snd $ fromJust $ encode5b6b rd inp
+
+tests :: TestTree
+tests = $(testGroupGenerator)

--- a/test/unit-tests.hs
+++ b/test/unit-tests.hs
@@ -15,6 +15,7 @@ import Test.Tasty
 
 import qualified Test.Cores.Crc
 import qualified Test.Cores.Etherbone
+import qualified Test.Cores.LineCoding.Lc5b6b
 import qualified Test.Cores.LineCoding.Lc8b10b
 #if MIN_VERSION_clash_prelude(1,9,0)
 import qualified Test.Cores.Sgmii.AutoNeg
@@ -35,6 +36,7 @@ tests :: TestTree
 tests = testGroup "Unittests" $
   [ Test.Cores.Crc.tests
   , Test.Cores.Etherbone.tests
+  , Test.Cores.LineCoding.Lc5b6b.tests
   , Test.Cores.LineCoding.Lc8b10b.tests
   , Test.Cores.SPI.tests
   , Test.Cores.SPI.MultiSlave.tests


### PR DESCRIPTION
Adds a very simple implementation of a 5b/6b encoder and decoder. Currently only one very crude unit test is written to verify that the general design of the encoder and decoder work, this will have to be expanded.

Feature-wise it is definitely not comparable to the 8b/10b encoder and decoder, but that core also contains some features I would (in hindsight) consider to be rather specific to SGMII. When I write the 3b/4b encoder and decoder and subsequently rewrite the 8b/10b encoder and decoder to use the smaller ones this could be re-evaluated.

The Haddock is not yet complete.