### PR TITLE
Bump wishbone

### DIFF
--- a/cabal.project-1.8
+++ b/cabal.project-1.8
@@ -2,10 +2,10 @@
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-compiler.git
-  tag: v1.8.2
+  tag: v1.8.4
   subdir: tests
 
 constraints:
-  clash-prelude == 1.8.2,
-  clash-lib == 1.8.2,
-  clash-ghc == 1.8.2
+  clash-prelude == 1.8.4,
+  clash-lib == 1.8.4,
+  clash-ghc == 1.8.4

--- a/cabal.project-common
+++ b/cabal.project-common
@@ -1,4 +1,4 @@
-index-state: 2025-02-20T12:11:59Z
+index-state: 2026-01-15T15:15:48Z
 
 packages:
   clash-cores.cabal
@@ -44,5 +44,14 @@ source-repository-package
   tag: 9b12c63dabaaa5a8228286bf9406b58c44a48359
   subdir: clash-protocols-base clash-protocols
 
+source-repository-package
+  type: git
+  location: https://github.com/clash-lang/ghc-typelits-natnormalise.git
+  tag: a4fdc5bf17f678e74a47bf3b8924c6a35e214fb2
+
 allow-newer:
-  clash-protocols:tasty
+  clash-protocols:tasty,
+  *:ghc-typelits-natnormalise,
+  *:ghc-typelits-knownnat,
+  *:ghc-typelits-extra,
+  *:ghc-tcplugin-api

--- a/cabal.project-common
+++ b/cabal.project-common
@@ -41,7 +41,7 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/clash-lang/clash-protocols.git
-  tag: 4fdfab2bf07679aa84d9efb38c84d00bcd8b2ed1
+  tag: 9b12c63dabaaa5a8228286bf9406b58c44a48359
   subdir: clash-protocols-base clash-protocols
 
 allow-newer:

--- a/flake.lock
+++ b/flake.lock
@@ -33,11 +33,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1763724643,
-        "narHash": "sha256-cqrViPu7pamyp+f235CZllzu5ivm200px/kKzQWdk8g=",
+        "lastModified": 1765828993,
+        "narHash": "sha256-njyNZfzGJsuRBUQyBgQys+e9BnyMcAhrXZKEYOmm7yY=",
         "owner": "clash-lang",
         "repo": "clash-compiler",
-        "rev": "91799cd9c964861e70762876f3af857fc6c4aedb",
+        "rev": "b5f11c51fd692aefc2922ba035fe6fee2b4f1035",
         "type": "github"
       },
       "original": {
@@ -55,11 +55,11 @@
         "flake-utils": "flake-utils_3"
       },
       "locked": {
-        "lastModified": 1763724657,
-        "narHash": "sha256-QMAoE1NjT5JtX8XMfgH+NiAz0nPnU2q1Ord8apHJMIs=",
+        "lastModified": 1767688939,
+        "narHash": "sha256-cgaxmOgpDbrPQ8heBHHrJUQIB4/k/+VRjGRryAV8WhA=",
         "owner": "clash-lang",
         "repo": "clash-protocols",
-        "rev": "4fdfab2bf07679aa84d9efb38c84d00bcd8b2ed1",
+        "rev": "9b12c63dabaaa5a8228286bf9406b58c44a48359",
         "type": "github"
       },
       "original": {

--- a/src/Clash/Cores/Etherbone/Base.hs
+++ b/src/Clash/Cores/Etherbone/Base.hs
@@ -66,14 +66,14 @@ data AddressSpace = WishboneAddressSpace | ConfigAddressSpace
   deriving (Generic, Show, ShowX, NFDataX, NFData, Eq)
 
 -- | Input data for 'Clash.Cores.Etherbone.WishboneMaster.wishboneMasterC' and 'Clash.Cores.Etherbone.ConfigMaster.configMasterC'
-data WishboneOperation addrWidth selWidth dat
+data WishboneOperation addrWidth dataWidth
   = WishboneOperation
   { _opAddr      :: BitVector addrWidth
   -- | Input data. This determines whether the operation is a read or a write.
   -- Read for @Nothing@, write for @Just@.
-  , _opDat       :: Maybe dat
+  , _opDat       :: Maybe (BitVector (dataWidth * 8))
   -- | Wishbone @sel@ field
-  , _opSel       :: BitVector selWidth
+  , _opSel       :: BitVector dataWidth
   -- | Indicates whether the @busCycle@ line should be dropped after the
   -- operation.
   , _opDropCyc   :: Bool
@@ -94,10 +94,10 @@ data WishboneOperation addrWidth selWidth dat
 
 -- | Output data from 'Clash.Cores.Etherbone.WishboneMaster.wishboneMasterC' and
 -- 'Clash.Cores.Etherbone.ConfigMaster.configMasterC'
-data WishboneResult dat
+data WishboneResult dataWidth
   = WishboneResult
   -- | @Nothing@ for a write and @Just dat@ for a read.
-  { _resDat  :: Maybe dat
+  { _resDat  :: Maybe (BitVector (dataWidth * 8))
   -- | Forwarded End-of-record flag
   , _resEOR  :: Bool
   -- | Forwarded End-of-packet flag
@@ -124,8 +124,6 @@ data Bypass addrWidth = Bypass
   -- into its initial state.
   , _bpAbort  :: Bool
   } deriving (Generic, NFDataX, NFData, Show, ShowX, Eq)
-
-type ByteSize dat = DivRU (BitSize dat) 8
 
 -- | Extract 'EBHeader' data from a @PacketStream@ into the metadata.
 -- With a 64-bit bus this shifts the data-stream by 4 bytes.

--- a/src/Clash/Cores/Etherbone/RecordBuilder.hs
+++ b/src/Clash/Cores/Etherbone/RecordBuilder.hs
@@ -69,17 +69,15 @@ data RecordBuilderState
 -- with no data and @_abort@ asserted as well.
 -- The ConfigMaster and WishboneMaster __may not__ send anything after an abort
 -- was asserted. So there is no need to manage the incoming Df data lines.
-recordBuilderT :: forall addrWidth dataWidth dat .
+recordBuilderT :: forall addrWidth dataWidth .
   ( KnownNat addrWidth
   , KnownNat dataWidth
-  , BitPack dat
-  , BitSize dat ~ dataWidth * 8
   , 4 <= dataWidth
   )
   => RecordBuilderState
   -> ( Maybe (Bypass addrWidth)
-     , Maybe (WishboneResult dat)  -- Config space
-     , Maybe (WishboneResult dat)  -- Wishbone space
+     , Maybe (WishboneResult dataWidth)  -- Config space
+     , Maybe (WishboneResult dataWidth)  -- Wishbone space
      , PacketStreamS2M
      )
   -> ( RecordBuilderState
@@ -269,17 +267,15 @@ bypassLatchT (Just bs) (Nothing, lst, bwd) = (nextState, Just bs)
 --
 -- This implementation waits not only for reads, but also for writes when
 -- constructing a response.
-recordBuilderC :: forall dom addrWidth dataWidth dat .
+recordBuilderC :: forall dom addrWidth dataWidth .
   ( HiddenClockResetEnable dom
   , KnownNat addrWidth
   , KnownNat dataWidth
-  , BitPack dat
-  , BitSize dat ~ dataWidth * 8
   , 4 <= dataWidth
   )
   => Circuit ( CSignal dom (Maybe (Bypass addrWidth))
-             , Df.Df dom (WishboneResult dat)  -- Config space
-             , Df.Df dom (WishboneResult dat)  -- Wishbone space
+             , Df.Df dom (WishboneResult dataWidth)  -- Config space
+             , Df.Df dom (WishboneResult dataWidth)  -- Wishbone space
              )
              (PacketStream dom dataWidth EBHeader)
 recordBuilderC = Circuit go

--- a/src/Clash/Cores/Etherbone/RecordProcessor.hs
+++ b/src/Clash/Cores/Etherbone/RecordProcessor.hs
@@ -34,12 +34,9 @@ data RecordProcessorState addrWidth
   | WaitForLast
   deriving (Show, Generic, ShowX, NFDataX)
 
-recordProcessorT :: forall dataWidth addrWidth dat .
+recordProcessorT :: forall dataWidth addrWidth .
   ( KnownNat dataWidth
   , KnownNat addrWidth
-  , BitPack dat
-  , BitSize dat ~ dataWidth * 8
-  , Show dat
   )
   => RecordProcessorState addrWidth
   -> ( Maybe (PacketStreamM2S dataWidth (Bool, RecordHeader))
@@ -48,7 +45,7 @@ recordProcessorT :: forall dataWidth addrWidth dat .
   -> ( RecordProcessorState addrWidth
      , ( PacketStreamS2M
        , Maybe (Bypass addrWidth)
-       , Maybe (WishboneOperation addrWidth dataWidth dat)
+       , Maybe (WishboneOperation addrWidth dataWidth)
        )
      )
 -- No data in -> no data out
@@ -186,17 +183,14 @@ recordProcessorT state (Just psFwd, Ack wbAck)
 -- of a Record packet, so that no additional edge-cases need to be handled here.
 -- The @Bool@ in the @_meta@ field indicates the end of a whole Etherbone
 -- packet, and is forwarded.
-recordProcessorC :: forall dom dataWidth addrWidth dat .
+recordProcessorC :: forall dom dataWidth addrWidth .
   ( HiddenClockResetEnable dom
   , KnownNat dataWidth
   , KnownNat addrWidth
-  , BitPack dat
-  , Show dat
-  , BitSize dat ~ dataWidth * 8
   )
   => Circuit (PacketStream dom dataWidth (Bool, RecordHeader))
              ( CSignal dom (Maybe (Bypass addrWidth))
-             , Df.Df dom (WishboneOperation addrWidth dataWidth dat)
+             , Df.Df dom (WishboneOperation addrWidth dataWidth)
              )
 recordProcessorC = forceResetSanity |> Circuit go
   where

--- a/stack.yaml
+++ b/stack.yaml
@@ -24,7 +24,7 @@ extra-deps:
   - git: https://github.com/cchalmers/circuit-notation.git
     commit: '564769c52aa05b90f81bbc898b7af7087d96613d'
   - git: https://github.com/clash-lang/clash-protocols.git
-    commit: '4fdfab2bf07679aa84d9efb38c84d00bcd8b2ed1'
+    commit: '9b12c63dabaaa5a8228286bf9406b58c44a48359'
     subdirs:
       - clash-protocols-base
       - clash-protocols

--- a/test/Test/Cores/Etherbone/WishboneMaster.hs
+++ b/test/Test/Cores/Etherbone/WishboneMaster.hs
@@ -22,7 +22,7 @@ import Clash.Cores.Etherbone.Base
 
 type WBData = C.BitVector 32
 
-genWishboneOperation :: Gen (WishboneOperation 32 4 WBData)
+genWishboneOperation :: Gen (WishboneOperation 32 4)
 genWishboneOperation = do
   _opAddr :: C.BitVector 32 <- Gen.integral Range.linearBounded
   _opDat :: Maybe WBData <- Gen.maybe $ Gen.integral Range.linearBounded
@@ -78,7 +78,7 @@ prop_wishboneMasterT = property $ do
       (state, result) = wishboneMasterT (last states) inp
 
     mapInput (wbOp, ack, wbAck) =
-      (wbOp, Ack ack, (emptyWishboneS2M @WBData){readData = readData, acknowledge = wbAck})
+      (wbOp, Ack ack, (emptyWishboneS2M @4){readData = readData, acknowledge = wbAck})
 
     getWb (_, _, x, _) = x
     getOutDat (_, Just x, _, _) = x


### PR DESCRIPTION
We changed the underlying types of `Wishbone` to operate on `BitVector (dataWidth * 8)` instead of the unconstrained `dat`. See https://github.com/clash-lang/clash-protocols/pull/184