### PR TITLE
Add Lattice PLLs

### DIFF
--- a/clash-cores.cabal
+++ b/clash-cores.cabal
@@ -164,6 +164,9 @@ library
       Clash.Cores.LatticeSemi.ECP5.Blackboxes.Pll
       Clash.Cores.LatticeSemi.ECP5.Internal.Pll
       Clash.Cores.LatticeSemi.ECP5.Pll
+      Clash.Cores.LatticeSemi.ICE40.Blackboxes.Pll
+      Clash.Cores.LatticeSemi.ICE40.Internal.Pll
+      Clash.Cores.LatticeSemi.ICE40.Pll
       Clash.Cores.Sgmii
       Clash.Cores.Sgmii.AutoNeg
       Clash.Cores.Sgmii.BitSlip
@@ -226,6 +229,7 @@ test-suite unit-tests
       process
     other-modules:
       Test.Cores.LatticeSemi.ECP5.Pll
+      Test.Cores.LatticeSemi.ICE40.Pll
       Test.Cores.Sgmii.AutoNeg
       Test.Cores.Sgmii.BitSlip
       Test.Cores.Sgmii.RateAdapt

--- a/clash-cores.cabal
+++ b/clash-cores.cabal
@@ -161,6 +161,9 @@ library
 
   if !flag(clash-18)
     exposed-modules:
+      Clash.Cores.LatticeSemi.ECP5.Blackboxes.Pll
+      Clash.Cores.LatticeSemi.ECP5.Internal.Pll
+      Clash.Cores.LatticeSemi.ECP5.Pll
       Clash.Cores.Sgmii
       Clash.Cores.Sgmii.AutoNeg
       Clash.Cores.Sgmii.BitSlip
@@ -219,7 +222,10 @@ test-suite unit-tests
     Test.Cores.Xilinx.Ethernet.Gmii
 
   if !flag(clash-18)
+    build-depends:
+      process
     other-modules:
+      Test.Cores.LatticeSemi.ECP5.Pll
       Test.Cores.Sgmii.AutoNeg
       Test.Cores.Sgmii.BitSlip
       Test.Cores.Sgmii.RateAdapt

--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,7 @@
           ];
 
           nativeBuildInputs = [
+            regular-pkgs.icestorm
             regular-pkgs.trellis
             hs-pkgs.cabal-install
             hs-pkgs.cabal-plan

--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,7 @@
           ];
 
           nativeBuildInputs = [
+            regular-pkgs.trellis
             hs-pkgs.cabal-install
             hs-pkgs.cabal-plan
             hs-pkgs.fourmolu

--- a/src/Clash/Cores/LatticeSemi/ECP5/Blackboxes/Pll.hs
+++ b/src/Clash/Cores/LatticeSemi/ECP5/Blackboxes/Pll.hs
@@ -1,0 +1,122 @@
+{-|
+  Copyright   :  (C) 2026, Felix Klein
+  License     :  CERN-OHL-P-2.0
+  Maintainer  :  felix@qbaylogic.com
+
+Blackbox implementation for the Lattice ECP5 PLLs.
+-}
+
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Clash.Cores.LatticeSemi.ECP5.Blackboxes.Pll where
+
+import Prelude
+
+import Clash.Backend (Backend)
+import Clash.Netlist.Types (TemplateFunction(..), BlackBoxContext)
+import Clash.Signal.Internal (ResetPolarity(..), periodToHz)
+
+import Control.Arrow (second)
+import Control.Monad.State (State)
+
+import Data.Text (Text)
+import Data.Text.Prettyprint.Doc.Extra (Doc)
+import Text.Show.Pretty (ppShow)
+
+import qualified Clash.Netlist.Id as Id
+import qualified Clash.Netlist.Types as N
+import qualified Clash.Primitives.DSL as DSL
+
+import Clash.Cores.LatticeSemi.ECP5.Internal.Pll
+
+-- | Blackbox implementation for 'Clash.Cores.LatticeSemi.ECP5.Pll.ecp5pll'.
+ecp5pllTF :: TemplateFunction
+ecp5pllTF = TemplateFunction [0,1,2,3] (const True) ecp5pllTF#
+
+-- | Generates HDL for the EHXPLLL primitive supported by ECP5 FPGAs.
+ecp5pllTF# :: Backend b => BlackBoxContext -> State b Doc
+ecp5pllTF# bbCtx
+  | [ (_, N.Void (Just  dIn@N.KnownDomain{}))
+    , (_, N.Void (Just dOut@N.KnownDomain{}))
+    , (srcClk, _)
+    , (srcRst, _)
+    ] <- DSL.tInputs bbCtx
+  , [ results ] <- DSL.tResults bbCtx
+  , N.KnownDomain _ pIn  _ _ _ rstPolarity <- dIn
+  , N.KnownDomain _ pOut _ _ _ _ <- dOut
+  , let componentName = "EHXPLLL" :: Text
+        iFreq, oFreq :: Rational
+        iFreq = periodToHz (fromInteger pIn ) / 1e6
+        oFreq = periodToHz (fromInteger pOut) / 1e6
+  = case calcPllParams iFreq oFreq of
+      Left err -> error $ "Blackbox Error (ecp5pll): " <> err
+      Right PllParams{..} -> do
+        -- shift the primary by 180 degrees; Lattice also seems to do this
+        let primaryCPhase = outputDiv `div` 2
+
+        instanceName <- Id.make $ componentName <> "_inst"
+        DSL.declaration (componentName <> "_block") $ do
+          (dstClk, locked) <-
+            DSL.untuple results ["pll_clk_out", "pll_lock_out"] >>= \case
+              [a, b] -> pure (a, b)
+              _ -> error $ ppShow bbCtx
+
+          cLow  <- DSL.assign "pll_cLow"  DSL.Low
+          cHigh <- DSL.assign "pll_cHigh" DSL.High
+          cReset <- case rstPolarity of
+            ActiveLow  -> DSL.notExpr "activeHighRst" srcRst
+            ActiveHigh -> return srcRst
+
+          let
+            generics :: [(Text, DSL.TExpr)]
+            generics = second DSL.litTExpr <$>
+              [ ("PLLRST_ENA",               "DISABLED")
+              , ("INTFB_WAKE",               "DISABLED")
+              , ("STDBY_ENABLE",             "DISABLED")
+              , ("DPHASE_SOURCE",            "DISABLED")
+              , ("OUTDIVIDER_MUXA",              "DIVA")
+              , ("OUTDIVIDER_MUXB",              "DIVB")
+              , ("OUTDIVIDER_MUXC",              "DIVC")
+              , ("OUTDIVIDER_MUXD",              "DIVD")
+              , ("CLKI_DIV",             DSL.I inputDiv)
+              , ("CLKOP_ENABLE",              "ENABLED")
+              , ("CLKOP_DIV",           DSL.I outputDiv)
+              , ("CLKOP_CPHASE",    DSL.I primaryCPhase)
+              , ("CLKOP_FPHASE",                      0)
+              , ("FEEDBK_PATH",                 "CLKOP")
+              , ("CLKFB_DIV",         DSL.I feedbackDiv)
+              ]
+
+            inPorts :: [(Text, DSL.TExpr)]
+            inPorts =
+              [ ("CLKI",         srcClk)
+              , ("CLKFB",        dstClk)
+              , ("PHASESEL0",      cLow)
+              , ("PHASESEL1",      cLow)
+              , ("PHASEDIR",      cHigh)
+              , ("PHASESTEP",     cHigh)
+              , ("PHASELOADREG",  cHigh)
+              , ("STDBY",          cLow)
+              , ("PLLWAKESYNC",    cLow)
+              , ("RST",          cReset)
+              , ("ENCLKOP",        cLow)
+              ]
+
+            outPorts :: [(Text, DSL.TExpr)]
+            outPorts =
+              [ ("CLKOP", dstClk)
+              , ("LOCK",  locked)
+              ]
+
+          DSL.instDecl
+            N.Empty
+            (Id.unsafeMake componentName)
+            instanceName
+            generics
+            inPorts
+            outPorts
+
+ecp5pllTF# bbCtx = error $ "Blackbox Error (ecp5pll): " <> ppShow bbCtx

--- a/src/Clash/Cores/LatticeSemi/ECP5/Internal/Pll.hs
+++ b/src/Clash/Cores/LatticeSemi/ECP5/Internal/Pll.hs
@@ -1,0 +1,137 @@
+{-|
+  Copyright   :  (C) 2026, Felix Klein
+  License     :  CERN-OHL-P-2.0
+  Maintainer  :  felix@qbaylogic.com
+
+The parameter limits and a configuration calculator for the tunable
+PLL parameters of the ECP5 FPGAs.
+
+The following relations are given according to the LatticeECP/EC and
+LatticeXP sysCLOCK PLL Design and Usage Guide:
+
+* output frequency = input frequency * (feedback divider / input divider)
+* voltage controlled oscillator frequency = output frequency * output divider
+* phase frequency detector frequency = input frequency / input divider
+-}
+
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Clash.Cores.LatticeSemi.ECP5.Internal.Pll where
+
+import Prelude
+
+import Data.Ratio ((%))
+
+-- | The limits according to the following Lattice data sheets:
+--
+--  * FPGA-DS-02012-3.4 ECP5 and ECP-5G Family
+--  * FPGA Libraries Reference Guide
+--
+data ECP5Limits = ECP5Limits
+  { -- | input frequency (MHz)
+    inputFreq :: Rational
+  , -- | output frequency (MHz)
+    outputFreq :: Rational
+  , -- | phase frequency detector frequency (Mhz)
+    pfdFreq :: Rational
+  , -- | voltage controlled oscillator frequency (MHz)
+    vcoFreq :: Rational
+  , -- | input divider
+    inputDiv :: Integer
+  , -- | output divider
+    outputDiv :: Integer
+  , -- | feedback divider
+    feedbackDiv :: Integer
+  }
+
+instance Bounded ECP5Limits where
+  minBound = ECP5Limits
+    { inputFreq   = 8
+    , outputFreq  = 10
+    , pfdFreq     = 25 % 8
+    , vcoFreq     = 400
+    , inputDiv    = 1
+    , outputDiv   = 1
+    , feedbackDiv = 1
+    }
+  maxBound = ECP5Limits
+    { inputFreq   = 400
+    , outputFreq  = 400
+    , pfdFreq     = 400
+    , vcoFreq     = 800
+    , inputDiv    = 128
+    , outputDiv   = 128
+    , feedbackDiv = 80
+    }
+
+-- | The tunable PLL parameters.
+data PllParams a = PllParams
+  { -- | input divider
+    inputDiv :: Integer
+  , -- | feedback divider
+    feedbackDiv :: Integer
+  , -- | output divider
+    outputDiv :: Integer
+  , -- | voltage controlled oscillator frequency (MHz)
+    vcoFreq :: a
+  , -- | output frequency (MHz)
+    outputFreq :: a
+  } deriving (Show, Eq)
+
+-- | Calculates optimized PLL parameters from the given input and
+-- output frequencies. The calculation is inspired by
+-- https://github.com/YosysHQ/prjtrellis/blob/main/libtrellis/tools/ecppll.cpp,
+-- but has been slightly improved through the usage of the error-free
+-- 'Rational' type instead of 'Float'.
+calcPllParams :: Rational -> Rational -> Either String (PllParams Rational)
+calcPllParams iFreq oFreq = do
+  guard (iFreq >= minima.inputFreq)
+    "The given input frequency exceeds the supported minimum."
+  guard (iFreq <= maxima.inputFreq)
+    "The given input frequency exceeds the supported maximum."
+  guard (oFreq >= minima.outputFreq)
+    "The targeted output frequency exceeds the supported minimum."
+  guard (oFreq <= maxima.outputFreq)
+    "The targeted output frequency exceeds the supported maximum."
+  snd <$> foldl optimize (Left "Could not find a suitable PLL parameter set.")
+    [ PllParams{..}
+    | inputDiv <- [minima.inputDiv .. maxInputDiv]
+    , let fpfd = iFreq / fromInteger inputDiv
+    , fpfd >= minima.pfdFreq
+    , fpfd <= maxima.pfdFreq
+    , feedbackDiv <- [minima.feedbackDiv .. maxFbDiv fpfd]
+    , outputDiv <- [minima.outputDiv .. maxOutputDiv fpfd]
+    , let vcoFreq = fpfd * fromInteger (feedbackDiv * outputDiv)
+    , vcoFreq >= minima.vcoFreq
+    , vcoFreq <= maxima.vcoFreq
+    , let outputFreq = vcoFreq / fromInteger outputDiv
+    ]
+ where
+  minima = minBound :: ECP5Limits
+  maxima = maxBound :: ECP5Limits
+
+  maxInputDiv = min maxima.inputDiv (floor (iFreq / minima.pfdFreq))
+  maxFbDiv fpfd = min maxima.feedbackDiv (floor (maxima.vcoFreq / fpfd))
+  maxOutputDiv fpfd = min maxima.outputDiv (floor (maxima.vcoFreq / fpfd))
+
+  optimize ma newParams = do
+    let newErr = abs $ newParams.outputFreq - oFreq
+    return $ case ma of
+      Right (oldErr, oldParams)
+        | newErr > oldErr                 -> (oldErr, oldParams)
+        | newErr < oldErr                 -> (newErr, newParams)
+        | vcod newParams < vcod oldParams -> (newErr, newParams)
+        | otherwise                       -> (oldErr, oldParams)
+      Left _                              -> (newErr, newParams)
+
+  guard cond errMsg = if cond then Right () else Left errMsg
+
+-- | Calculates the distance to the targeted VCO frequency.
+vcod :: Fractional a => PllParams a -> a
+vcod x = abs $ x.vcoFreq - fromRational targetVcoFreq
+ where
+  targetVcoFreq = minima.vcoFreq + (maxima.vcoFreq - minima.vcoFreq) / 2
+  minima = minBound :: ECP5Limits
+  maxima = maxBound :: ECP5Limits

--- a/src/Clash/Cores/LatticeSemi/ECP5/Pll.hs
+++ b/src/Clash/Cores/LatticeSemi/ECP5/Pll.hs
@@ -1,0 +1,54 @@
+{-|
+  Copyright   :  (C) 2026, Felix Klein
+  License     :  CERN-OHL-P-2.0
+  Maintainer  :  felix@qbaylogic.com
+
+This module contains functions for instantiating clock generators on
+Lattice ECP5 FPGA's.
+
+We suggest you use a clock generator even if your oscillator runs at
+the frequency you want to run your circuit at.
+
+A clock generator generates a stable clock signal for your design at a
+configurable frequency. A clock generator in an FPGA is frequently
+referred to as a PLL (Phase-Locked Loop). Lattice also refers to them
+as PLL's in general but because this is not consistently the case
+among FPGA vendors, we choose the more generic term clock generator.
+-}
+
+{-# LANGUAGE QuasiQuotes #-}
+
+module Clash.Cores.LatticeSemi.ECP5.Pll (ecp5pll) where
+
+import Clash.Prelude
+
+import Clash.Annotations.Primitive (Primitive(..), HDL(..), hasBlackBox)
+import Clash.Cores.LatticeSemi.ECP5.Blackboxes.Pll (ecp5pllTF)
+import Clash.Clocks (Clocks(..))
+import Data.String.Interpolate (__i)
+
+-- | Instantiates a Lattice clock generator using the EHXPLLL
+-- primitive supported by the Lattice ECP5 FPGAs.
+ecp5pll ::
+  forall domIn domOut.
+  (HasAsynchronousReset domIn, KnownDomain domOut) =>
+  -- | Free running clock (e.g. a clock pin connected to a crystal
+  -- oscillator)
+  Clock domIn ->
+  -- | Reset for the clock generator
+  Reset domIn ->
+  (Clock domOut, Signal domOut Bool)
+ecp5pll = clocks
+{-# OPAQUE ecp5pll #-}
+{-# ANN ecp5pll hasBlackBox #-}
+{-# ANN ecp5pll
+  let
+    primName = show 'ecp5pll
+    tfName = show 'ecp5pllTF
+  in InlineYamlPrimitive [Verilog, SystemVerilog] [__i|
+    BlackBox:
+      name: #{primName}
+      kind: Declaration
+      format: Haskell
+      templateFunction: #{tfName}
+  |] #-}

--- a/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/Pll.hs
+++ b/src/Clash/Cores/LatticeSemi/ICE40/Blackboxes/Pll.hs
@@ -1,0 +1,113 @@
+{-|
+  Copyright   :  (C) 2026, Felix Klein
+  License     :  CERN-OHL-P-2.0
+  Maintainer  :  felix@qbaylogic.com
+
+Blackbox implementation for the Lattice ICE40 PLLs.
+-}
+
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MagicHash #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Clash.Cores.LatticeSemi.ICE40.Blackboxes.Pll where
+
+import Prelude
+
+import Clash.Backend (Backend)
+import Clash.Netlist.Types (TemplateFunction(..), BlackBoxContext)
+import Clash.Signal.Internal (ResetPolarity(..), periodToHz)
+
+import Control.Arrow (second)
+import Control.Monad.State (State)
+
+import Data.Text (Text)
+import Data.Text.Prettyprint.Doc.Extra (Doc)
+import Text.Show.Pretty (ppShow)
+
+import qualified Clash.Netlist.Id as Id
+import qualified Clash.Netlist.Types as N
+import qualified Clash.Primitives.DSL as DSL
+
+import Clash.Cores.LatticeSemi.ICE40.Internal.Pll
+
+-- | Blackbox implementation for
+-- 'Clash.Cores.LatticeSemi.ICE40.Pll.ice40Corepll'.
+ice40pllCoreTF :: TemplateFunction
+ice40pllCoreTF = TemplateFunction [0,1,2,3] (const True) (ice40pllTF# False)
+
+-- | Blackbox implementation for
+-- 'Clash.Cores.LatticeSemi.ICE40.Pll.ice40Padpll'.
+ice40pllPadTF :: TemplateFunction
+ice40pllPadTF = TemplateFunction [0,1,2,3] (const True) (ice40pllTF# True)
+
+-- | Generates HDL for the SB_PLL40_(CORE/PAD) primitives supported by
+-- ICE40 FPGAs.
+ice40pllTF# :: Backend b => Bool -> BlackBoxContext -> State b Doc
+ice40pllTF# isPad bbCtx
+  | [ (_, N.Void (Just  dIn@N.KnownDomain{}))
+    , (_, N.Void (Just dOut@N.KnownDomain{}))
+    , (srcClk, _)
+    , (srcRst, _)
+    ] <- DSL.tInputs bbCtx
+  , [ results ] <- DSL.tResults bbCtx
+  , N.KnownDomain _ pIn  _ _ _ rstPolarity <- dIn
+  , N.KnownDomain _ pOut _ _ _ _ <- dOut
+  , let componentName =
+          if isPad then "SB_PLL40_PAD" :: Text else "SB_PLL40_CORE"
+        iFreq, oFreq :: Rational
+        iFreq = periodToHz (fromInteger pIn ) / 1e6
+        oFreq = periodToHz (fromInteger pOut) / 1e6
+        pllType = if isPad then "Pad" else "Core"
+  = case calcPllParams iFreq oFreq of
+      Left err -> error $ "Blackbox Error (ice40pll" <> pllType <> "): " <> err
+      Right PllParams{..} -> do
+        instanceName <- Id.make $ componentName <> "_inst"
+        DSL.declaration (componentName <> "_block") $ do
+          (dstClk, locked) <-
+            DSL.untuple results ["pll_clk_out", "pll_lock_out"] >>= \case
+              [a, b] -> pure (a, b)
+              _ -> error $ ppShow bbCtx
+
+          cLow <- DSL.assign "pll_cLow"  DSL.Low
+          cReset <- case rstPolarity of
+            ActiveLow  -> return srcRst
+            ActiveHigh -> DSL.notExpr "activeLowRst" srcRst
+
+          let
+            generics :: [(Text, DSL.TExpr)]
+            generics = second DSL.litTExpr <$>
+              [ ("FEEDBACK_PATH",          "SIMPLE")
+              , ("PLLOUT_SELECT",          "GENCLK")
+              , ("DIVR",            DSL.I refClkDiv)
+              , ("DIVF",          DSL.I feedbackDiv)
+              , ("DIVQ",               DSL.I vcoDiv)
+              , ("FILTER_RANGE",  DSL.I filterRange)
+              ]
+
+            inPorts :: [(Text, DSL.TExpr)]
+            inPorts =
+              [ ("RESETB",                                       cReset)
+              , ("BYPASS",                                         cLow)
+              , (if isPad then "PACKAGEPIN" else "REFERENCECLK", srcClk)
+              ]
+
+            outPorts :: [(Text, DSL.TExpr)]
+            outPorts =
+              [ ("PLLOUTCORE",   dstClk)
+              , ("LOCK", locked)
+              ]
+
+          DSL.instDecl
+            N.Empty
+            (Id.unsafeMake componentName)
+            instanceName
+            generics
+            inPorts
+            outPorts
+
+ice40pllTF# isPad bbCtx =
+  error $ "Blackbox Error (ice40pll" <> pllType <> "): " <> ppShow bbCtx
+ where
+  pllType = if isPad then "Pad" else "Core"

--- a/src/Clash/Cores/LatticeSemi/ICE40/Internal/Pll.hs
+++ b/src/Clash/Cores/LatticeSemi/ICE40/Internal/Pll.hs
@@ -1,0 +1,145 @@
+{-|
+  Copyright   :  (C) 2026, Felix Klein
+  License     :  CERN-OHL-P-2.0
+  Maintainer  :  felix@qbaylogic.com
+
+The parameter limits and a configuration calculator for the tunable
+PLL parameters of the ICE40 FPGAs. This module currently only supports
+the FEEDBACK_PATH = SIMPLE option.
+
+The following relations are given according to the iCE40 sysCLOCK PLL
+Design and User Guide:
+
+* output frequency = (input frequency * (feedback divider + 1)
+    / (2 ^ (VCO divider) * (reference clock divider + 1))
+-}
+
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Clash.Cores.LatticeSemi.ICE40.Internal.Pll where
+
+import Prelude
+
+-- | The limits according to the following Lattice data sheets:
+--
+--  * FPGA-DS-02027-1.9 iCE40 UltraLite Family Data Sheet
+--  * FPGA-TN-02052-1.4 iCE40 sysCLOCK PLL Design and User Guide
+--
+data ICE40Limits = ICE40Limits
+  { -- | input frequency (MHz)
+    inputFreq :: Rational
+  , -- | output frequency (MHz)
+    outputFreq :: Rational
+  , -- | phase frequency detector frequency (MHz)
+    pfdFreq :: Rational
+  , -- | voltage controlled oscillator frequency (MHz)
+    vcoFreq :: Rational
+  , -- | reference clock divider
+    refClkDiv :: Integer
+  , -- | feedback divider
+    feedbackDiv :: Integer
+  , -- | voltage controlled oscillator divider
+    vcoDiv :: Integer
+  }
+
+instance Bounded ICE40Limits where
+  minBound = ICE40Limits
+    { inputFreq   = 10
+    , outputFreq  = 16
+    , pfdFreq     = 10
+    , vcoFreq     = 533
+    , refClkDiv   = 0
+    , feedbackDiv = 0
+    , vcoDiv      = 0
+    }
+  maxBound = ICE40Limits
+    { inputFreq   = 133
+    , outputFreq  = 275
+    , pfdFreq     = 133
+    , vcoFreq     = 1066
+    , refClkDiv   = 15
+    , feedbackDiv = 127
+    , vcoDiv      = 7
+    }
+
+-- | The tunable PLL parameters.
+data PllParams a = PllParams
+  { -- | reference clock divider
+    refClkDiv :: Integer
+  , -- | feedback divider
+    feedbackDiv :: Integer
+  , -- | voltage controlled oscillator divider
+    vcoDiv :: Integer
+  , -- | PLL filter range
+    filterRange :: Integer
+  , -- | voltage controlled oscillator frequency (MHz)
+    vcoFreq :: a
+  , -- | output frequency (MHz)
+    outputFreq :: a
+  } deriving (Show, Eq)
+
+-- | Calculates optimized PLL parameters from the given input and
+-- output frequencies. The calculation is inspired by
+-- https://github.com/YosysHQ/icestorm/blob/main/icepll/icepll.cc, but
+-- has been slightly improved through the usage of the error-free
+-- 'Rational' type instead of 'Float'.
+calcPllParams :: Rational -> Rational -> Either String (PllParams Rational)
+calcPllParams iFreq oFreq = do
+  guard (iFreq >= minima.inputFreq)
+    "The given input frequency exceeds the supported minimum."
+  guard (iFreq <= maxima.inputFreq)
+    "The given input frequency exceeds the supported maximum."
+  guard (oFreq >= minima.outputFreq)
+    "The targeted output frequency exceeds the supported minimum."
+  guard (oFreq <= maxima.outputFreq)
+    "The targeted output frequency exceeds the supported maximum."
+  snd <$> foldl optimize (Left "Could not find a suitable PLL parameter set.")
+    [ PllParams{..}
+    | refClkDiv <- [minima.refClkDiv .. maxRefClkDiv]
+    , let fpfd = iFreq / fromInteger (refClkDiv + 1)
+    , fpfd >= minima.pfdFreq
+    , fpfd <= maxima.pfdFreq
+    , feedbackDiv <- [minima.feedbackDiv .. maxFbDiv fpfd]
+    , let vcoFreq = fpfd * fromInteger (feedbackDiv + 1)
+    , vcoFreq >= minima.vcoFreq
+    , vcoFreq <= maxima.vcoFreq
+    , vcoDiv <- [minima.vcoDiv .. maxima.vcoDiv]
+    , let outputFreq = vcoFreq / (2 ^ vcoDiv)
+    , -- the same calculation as used by icepll
+      let filterRange
+            | fpfd < 17  = 1
+            | fpfd < 26  = 2
+            | fpfd < 44  = 3
+            | fpfd < 66  = 4
+            | fpfd < 101 = 5
+            | otherwise  = 6
+    ]
+ where
+  minima = minBound :: ICE40Limits
+  maxima = maxBound :: ICE40Limits
+
+  maxRefClkDiv :: Integer
+  maxRefClkDiv = min maxima.refClkDiv (floor (iFreq / minima.pfdFreq) - 1)
+  maxFbDiv fpfd = min maxima.feedbackDiv (floor (maxima.vcoFreq / fpfd) - 1)
+
+  optimize ma newParams = do
+    let newErr = abs $ newParams.outputFreq - oFreq
+    return $ case ma of
+      Right (oldErr, oldParams)
+        | newErr > oldErr                 -> (oldErr, oldParams)
+        | newErr < oldErr                 -> (newErr, newParams)
+        | vcod newParams < vcod oldParams -> (newErr, newParams)
+        | otherwise                       -> (oldErr, oldParams)
+      Left _                              -> (newErr, newParams)
+
+  guard cond errMsg = if cond then Right () else Left errMsg
+
+-- | Calculates the distance to the targeted VCO frequency.
+vcod :: Fractional a => PllParams a -> a
+vcod x = abs $ x.vcoFreq - fromRational targetVcoFreq
+ where
+  targetVcoFreq = minima.vcoFreq + (maxima.vcoFreq - minima.vcoFreq) / 2
+  minima = minBound :: ICE40Limits
+  maxima = maxBound :: ICE40Limits

--- a/src/Clash/Cores/LatticeSemi/ICE40/Pll.hs
+++ b/src/Clash/Cores/LatticeSemi/ICE40/Pll.hs
@@ -1,0 +1,86 @@
+{-|
+  Copyright   :  (C) 2026, Felix Klein
+  License     :  CERN-OHL-P-2.0
+  Maintainer  :  felix@qbaylogic.com
+
+This module contains functions for instantiating clock generators on
+Lattice ICE40 FPGA's.
+
+We suggest you use a clock generator even if your oscillator runs at
+the frequency you want to run your circuit at.
+
+A clock generator generates a stable clock signal for your design at a
+configurable frequency. A clock generator in an FPGA is frequently
+referred to as a PLL (Phase-Locked Loop). Lattice also refers to them
+as PLL's in general but because this is not consistently the case
+among FPGA vendors, we choose the more generic term clock generator.
+-}
+
+{-# LANGUAGE QuasiQuotes #-}
+
+module Clash.Cores.LatticeSemi.ICE40.Pll
+  ( ice40pllCore
+  , ice40pllPad
+  ) where
+
+import Clash.Prelude
+
+import Clash.Annotations.Primitive (Primitive(..), HDL(..), hasBlackBox)
+import Clash.Cores.LatticeSemi.ICE40.Blackboxes.Pll
+  (ice40pllCoreTF, ice40pllPadTF)
+import Clash.Clocks (Clocks(..))
+import Data.String.Interpolate (__i)
+
+-- | Instantiates a Lattice clock generator using the SB_PLL40_CORE
+-- primitive. This primitive shall be used exclusively for internal
+-- reference clocks.
+ice40pllCore ::
+  forall domIn domOut.
+  (HasAsynchronousReset domIn, KnownDomain domOut) =>
+  -- | Free running clock (e.g. a clock pin connected to a crystal
+  -- oscillator)
+  Clock domIn ->
+  -- | Reset for the clock generator
+  Reset domIn ->
+  (Clock domOut, Signal domOut Bool)
+ice40pllCore = clocks
+{-# OPAQUE ice40pllCore #-}
+{-# ANN ice40pllCore hasBlackBox #-}
+{-# ANN ice40pllCore
+  let
+    primName = show 'ice40pllCore
+    tfName = show 'ice40pllCoreTF
+  in InlineYamlPrimitive [Verilog, SystemVerilog] [__i|
+    BlackBox:
+      name: #{primName}
+      kind: Declaration
+      format: Haskell
+      templateFunction: #{tfName}
+  |] #-}
+
+-- | Instantiates a Lattice clock generator using the SB_PLL40_PAD
+-- primitive. This primitive shall be used exclusively for external
+-- reference clocks.
+ice40pllPad ::
+  forall domIn domOut.
+  (HasAsynchronousReset domIn, KnownDomain domOut) =>
+  -- | Free running clock (e.g. a clock pin connected to a crystal
+  -- oscillator)
+  Clock domIn ->
+  -- | Reset for the clock generator
+  Reset domIn ->
+  (Clock domOut, Signal domOut Bool)
+ice40pllPad = clocks
+{-# OPAQUE ice40pllPad #-}
+{-# ANN ice40pllPad hasBlackBox #-}
+{-# ANN ice40pllPad
+  let
+    primName = show 'ice40pllPad
+    tfName = show 'ice40pllPadTF
+  in InlineYamlPrimitive [Verilog, SystemVerilog] [__i|
+    BlackBox:
+      name: #{primName}
+      kind: Declaration
+      format: Haskell
+      templateFunction: #{tfName}
+  |] #-}

--- a/test/Test/Cores/LatticeSemi/ECP5/Pll.hs
+++ b/test/Test/Cores/LatticeSemi/ECP5/Pll.hs
@@ -1,0 +1,97 @@
+{-|
+  Copyright   :  (C) 2026, Felix Klein
+  License     :  CERN-OHL-P-2.0
+  Maintainer  :  felix@qbaylogic.com
+
+Property based tests for Clash.Cores.LatticeSemi.ECP5.Pll. Note that
+this test suite requires the ecppll tool from project Trellis to be in
+the PATH.
+-}
+
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Test.Cores.LatticeSemi.ECP5.Pll (tests) where
+
+import Prelude
+
+import Control.Monad.IO.Class (liftIO)
+import Data.Ratio ((%))
+import Hedgehog ((===), assert, forAll, property)
+import Hedgehog.Gen (int)
+import Hedgehog.Range (linear)
+import Test.Tasty (TestTree)
+import Test.Tasty.Hedgehog (testProperty)
+import Text.Read (readMaybe)
+import System.Exit (ExitCode(..))
+import System.IO (hGetContents)
+import System.Process (runInteractiveProcess, waitForProcess)
+
+import Clash.Cores.LatticeSemi.ECP5.Internal.Pll
+
+admissibleFloatErr :: Float
+admissibleFloatErr = 0.001
+
+tests :: TestTree
+tests = testProperty "Test.Cores.LatticeSemi.ECP5.Pll" $ property $ do
+  let forAllFreq x y = forAll $ int $ linear (fromEnum x) (fromEnum y)
+  iFreq <- forAllFreq minima.inputFreq maxima.inputFreq
+  oFreq <- forAllFreq minima.outputFreq maxima.outputFreq
+
+  Just golden <- liftIO $ getGoldenParams (toEnum iFreq) (toEnum oFreq)
+  Right params <- return $ calcPllParams (toRational iFreq) (toRational oFreq)
+
+  -- the output frequency is as good as the golden reference
+  let errParams = abs (toRational oFreq - params.outputFreq)
+      errGolden = abs (toEnum oFreq - golden.outputFreq)
+  assert $ fromRational errParams <= errGolden + admissibleFloatErr
+
+  -- the VCO frequency is at least as close to the targeted frequency
+  -- as the golden reference
+  assert $ fromRational (vcod params) <= vcod golden + admissibleFloatErr
+
+  -- the PFD frequency is within range
+  let fpfd = toRational iFreq / toRational params.inputDiv
+  assert $ fpfd >= minima.pfdFreq
+  assert $ fpfd <= maxima.pfdFreq
+
+  -- the VCO frequency is within range
+  assert $ params.vcoFreq >= minima.vcoFreq
+  assert $ params.vcoFreq <= maxima.vcoFreq
+
+  -- output frequency = input frequency * (feedback divider / input divider)
+  params.outputFreq
+    === (toInteger iFreq * params.feedbackDiv) % params.inputDiv
+  let oFreqCalc = (toInteger iFreq * golden.feedbackDiv) % golden.inputDiv
+  assert $ abs (golden.outputFreq - fromRational oFreqCalc) < admissibleFloatErr
+
+  -- VCO frequency = output frequency * output divider
+  params.vcoFreq === params.outputFreq * toRational params.outputDiv
+  let vcoFreqCalc = golden.outputFreq * fromInteger golden.outputDiv
+  assert $ abs (golden.vcoFreq - vcoFreqCalc) < 10 * admissibleFloatErr
+ where
+  minima = minBound :: ECP5Limits
+  maxima = maxBound :: ECP5Limits
+
+getGoldenParams :: Float -> Float -> IO (Maybe (PllParams Float))
+getGoldenParams iFreq oFreq = do
+  (_, out, _, pid) <- runInteractiveProcess
+    "ecppll" [ "-i", show iFreq, "-o", show oFreq ] Nothing Nothing
+  waitForProcess pid >>= \case
+    ExitFailure{} -> return Nothing
+    ExitSuccess   -> hGetContents out >>= \str -> return $ do
+      [_, l0, l1, l2, l3, l4] <- return $ lines str
+      [_, _, w0] <- return $ words l0
+      [_, _, w1] <- return $ words l1
+      [_, _, w2] <- return $ words l2
+      [_, _, w3, _] <- return $ words l3
+      [_, _, w4] <- return $ words l4
+      inputDiv <- readMaybe w0
+      feedbackDiv <- readMaybe w1
+      outputDiv <- readMaybe w2
+      outputFreq <- readMaybe w3
+      vcoFreq <- readMaybe w4
+      return PllParams{..}

--- a/test/Test/Cores/LatticeSemi/ICE40/Pll.hs
+++ b/test/Test/Cores/LatticeSemi/ICE40/Pll.hs
@@ -1,0 +1,98 @@
+{-|
+  Copyright   :  (C) 2026, Felix Klein
+  License     :  CERN-OHL-P-2.0
+  Maintainer  :  felix@qbaylogic.com
+
+Property based tests for Clash.Cores.LatticeSemi.ICE40.Pll. Note that
+this test suite requires the icepll tool from project icestorm to be in
+the PATH.
+-}
+
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiWayIf #-}
+{-# LANGUAGE OverloadedRecordDot #-}
+{-# LANGUAGE RecordWildCards #-}
+
+module Test.Cores.LatticeSemi.ICE40.Pll (tests) where
+
+import Prelude
+
+import Control.Monad.IO.Class (liftIO)
+import Data.Ratio ((%))
+import Hedgehog ((===), assert, forAll, property)
+import Hedgehog.Gen (int)
+import Hedgehog.Range (linear)
+import Test.Tasty (TestTree)
+import Test.Tasty.Hedgehog (testProperty)
+import Text.Read (readMaybe)
+import System.Exit (ExitCode(..))
+import System.IO (hGetContents)
+import System.Process (runInteractiveProcess, waitForProcess)
+
+import Clash.Cores.LatticeSemi.ICE40.Internal.Pll
+
+admissibleFloatErr :: Float
+admissibleFloatErr = 0.001
+
+tests :: TestTree
+tests = testProperty "Test.Cores.LatticeSemi.ICE40.Pll" $ property $ do
+  let forAllFreq x y = forAll $ int $ linear (fromEnum x) (fromEnum y)
+  iFreq <- forAllFreq minima.inputFreq maxima.inputFreq
+  oFreq <- forAllFreq minima.outputFreq maxima.outputFreq
+
+  Just golden <- liftIO $ getGoldenParams (toEnum iFreq) (toEnum oFreq)
+  Right params <- return $ calcPllParams (toRational iFreq) (toRational oFreq)
+
+  -- the output frequency is as good as the golden reference
+  let errParams = abs (toRational oFreq - params.outputFreq)
+      errGolden = abs (toEnum oFreq - golden.outputFreq)
+  assert $ fromRational errParams <= errGolden + admissibleFloatErr
+
+  -- the VCO frequency is at least as close to the targeted frequency
+  -- as the golden reference
+  assert $ fromRational (vcod params) <= vcod golden + admissibleFloatErr
+
+  -- the PFD frequency is within range
+  let fpfd = toRational iFreq / toRational (params.refClkDiv + 1)
+  assert $ fpfd >= minima.pfdFreq
+  assert $ fpfd <= maxima.pfdFreq
+
+  -- the VCO frequency is within range
+  assert $ params.vcoFreq >= minima.vcoFreq
+  assert $ params.vcoFreq <= maxima.vcoFreq
+
+  -- output frequency = (input frequency * (feedback divider + 1)
+  --   / (2 ^ (VCO divider) * (reference clock divider + 1))
+  params.outputFreq
+    === (toInteger iFreq * (params.feedbackDiv + 1))
+          % ((params.refClkDiv + 1) * 2 ^ params.vcoDiv)
+  let oFreqCalc = (toInteger iFreq * (golden.feedbackDiv + 1))
+                    % ((golden.refClkDiv + 1) * 2 ^ golden.vcoDiv)
+  assert $ abs (golden.outputFreq - fromRational oFreqCalc) < admissibleFloatErr
+ where
+  minima = minBound :: ICE40Limits
+  maxima = maxBound :: ICE40Limits
+
+getGoldenParams :: Float -> Float -> IO (Maybe (PllParams Float))
+getGoldenParams iFreq oFreq = do
+  (_, out, _, pid) <- runInteractiveProcess
+    "icepll" [ "-i", show iFreq, "-o", show oFreq ] Nothing Nothing
+  waitForProcess pid >>= \case
+    ExitFailure{} -> return Nothing
+    ExitSuccess   -> hGetContents out >>= \str -> return $ do
+      [_, _, l0, _, _, l1, l2, l3, l4, l5] <- return
+        $ filter (not . null) $ lines str
+      [_, w0, _, _] <- return $ words l0
+      [_, w1, _] <- return $ words l1
+      [_, w2, _] <- return $ words l2
+      [_, w3, _] <- return $ words l3
+      [_, w4, _] <- return $ words l4
+      [_, w5, _] <- return $ words l5
+      outputFreq <- readMaybe w0
+      vcoFreq <- readMaybe w1
+      refClkDiv <- readMaybe w2
+      feedbackDiv <- readMaybe w3
+      vcoDiv <- readMaybe w4
+      filterRange <- readMaybe w5
+      return PllParams{..}

--- a/test/unit-tests.hs
+++ b/test/unit-tests.hs
@@ -18,6 +18,7 @@ import qualified Test.Cores.Etherbone
 import qualified Test.Cores.LineCoding.Lc8b10b
 #if MIN_VERSION_clash_prelude(1,9,0)
 import qualified Test.Cores.LatticeSemi.ECP5.Pll
+import qualified Test.Cores.LatticeSemi.ICE40.Pll
 import qualified Test.Cores.Sgmii.AutoNeg
 import qualified Test.Cores.Sgmii.BitSlip
 import qualified Test.Cores.Sgmii.RateAdapt
@@ -50,6 +51,7 @@ tests_modern :: [TestTree]
 #if MIN_VERSION_clash_prelude(1,9,0)
 tests_modern =
   [ Test.Cores.LatticeSemi.ECP5.Pll.tests
+  , Test.Cores.LatticeSemi.ICE40.Pll.tests
   , Test.Cores.Sgmii.AutoNeg.tests
   , Test.Cores.Sgmii.BitSlip.tests
   , Test.Cores.Sgmii.RateAdapt.tests

--- a/test/unit-tests.hs
+++ b/test/unit-tests.hs
@@ -17,6 +17,7 @@ import qualified Test.Cores.Crc
 import qualified Test.Cores.Etherbone
 import qualified Test.Cores.LineCoding.Lc8b10b
 #if MIN_VERSION_clash_prelude(1,9,0)
+import qualified Test.Cores.LatticeSemi.ECP5.Pll
 import qualified Test.Cores.Sgmii.AutoNeg
 import qualified Test.Cores.Sgmii.BitSlip
 import qualified Test.Cores.Sgmii.RateAdapt
@@ -48,7 +49,8 @@ tests = testGroup "Unittests" $
 tests_modern :: [TestTree]
 #if MIN_VERSION_clash_prelude(1,9,0)
 tests_modern =
-  [ Test.Cores.Sgmii.AutoNeg.tests
+  [ Test.Cores.LatticeSemi.ECP5.Pll.tests
+  , Test.Cores.Sgmii.AutoNeg.tests
   , Test.Cores.Sgmii.BitSlip.tests
   , Test.Cores.Sgmii.RateAdapt.tests
   , Test.Cores.Sgmii.Sgmii.tests


### PR DESCRIPTION
The PR adds some simple PLL blackbox primitives for the ECP5 and ICE40 FPGAs from Lattice, where the calculations of the different parameters mirror the implementations of the [ecppll](https://github.com/YosysHQ/prjtrellis/blob/main/libtrellis/tools/ecppll.cpp) tool from Project Trellis and the [icepll](https://github.com/YosysHQ/icestorm/blob/main/icepll/icepll.cc) tool from Project IceStorm, just being implemented in Haskell instead. As a consequence, the new implementations also improve against the existing tools by using `Rational` instead of `Float`, which avoids potential rounding errors sometimes leading to even better configurations than given by `ecppll` and `icepll`.

The calculated parameters are tested against the parameters of the existing tools via property based tests. Moreover, I also tested some configurations manually using the open source Yosys toolchain, an oscilloscope and a physical device, where devices under tests had been 
* an [OrangeCrab](https://orangecrab-fpga.github.io/orangecrab-hardware) development board for the ECP5 FPGA, and 
* an [iCEstick](https://www.latticesemi.com/en/Products/DevelopmentBoardsAndKits/iCEstick) development board for the ICE40 FPGA.

Note that the given blackbox wrappers don't offer all the configuration options as given by the PLL library primitives. However, they should be sufficiently comfortable for starter projects, where mostly the regulation of the clock frequency is of primary concern at first.