### PR TITLE
Refactor ILA to merge probe config and definition 

### DIFF
--- a/hdl-tests/shouldwork/Xilinx/Ila.hs
+++ b/hdl-tests/shouldwork/Xilinx/Ila.hs
@@ -9,6 +9,7 @@ import System.Directory
 import System.Environment
 import System.FilePath
 import System.FilePath.Glob
+import GHC.Stack (HasCallStack)
 import qualified Language.Haskell.TH as TH
 
 import Clash.Annotations.TH
@@ -22,16 +23,19 @@ top = 0
 {-# OPAQUE top #-}
 makeTopEntity 'top
 
-oneCounter :: IlaConfig 1 -> Clock Dom -> Signal Dom ()
-oneCounter config clk = setName @"one_counter_ila" $ ila @Dom config clk counter
+oneCounter :: Clock Dom -> Signal Dom ()
+oneCounter clk = setName @"one_counter_ila" $ ila @Dom clk (probe "foo" counter)
  where
   counter :: Signal Dom (Unsigned 64)
   counter = register clk noReset enableGen 0 (counter + 1)
 
-threeCounters :: IlaConfig 3 -> Clock Dom -> Signal Dom ()
+threeCounters :: IlaConfig -> Clock Dom -> Signal Dom ()
 threeCounters config clk =
   setName @"three_counters_ila" $
-    ila @Dom config clk counter0 counter1 counter2
+    ilaWith @Dom config clk
+      (probe "foo"   counter0)
+      (probe "bar"   counter1)
+      (probe "ipsum" counter2)
  where
   counter0 :: Signal Dom (Unsigned 64)
   counter0 = register clk noReset enableGen 0 (counter0 + 1)
@@ -43,49 +47,59 @@ threeCounters config clk =
   counter2 = register clk noReset enableGen 0 (counter2 + 3)
 
 testWithDefaultsOne :: Clock Dom -> Signal Dom ()
-testWithDefaultsOne = oneCounter (ilaConfig ("foo" :> Nil))
+testWithDefaultsOne = oneCounter
 {-# ANN testWithDefaultsOne (TestBench 'top) #-}
 {-# ANN testWithDefaultsOne (defSyn "testWithDefaultsOne") #-}
 
 testWithDefaultsThree :: Clock Dom -> Signal Dom ()
-testWithDefaultsThree = threeCounters (ilaConfig ("foo" :> "bar" :> "ipsum" :> Nil))
+testWithDefaultsThree = threeCounters ilaConfig
 {-# ANN testWithDefaultsThree (TestBench 'top) #-}
 {-# ANN testWithDefaultsThree (defSyn "testWithDefaultsThree") #-}
 
 testWithLefts :: Clock Dom -> Signal Dom ()
-testWithLefts = threeCounters $
-  (ilaConfig ("foo" :> "bar" :> "ipsum" :> Nil))
-    { comparators = Left 3
-    , probeTypes = Left Data
-    , depth = D2048
-    , captureControl = False
-    , stages = 5
-    }
+testWithLefts = threeCountersPerProbe
+  (ilaConfig { depth = D2048, captureControl = False, stages = 5 })
+  (probeConfig { comparators = 3, probeType = Data })
+  (probeConfig { comparators = 3, probeType = Data })
+  (probeConfig { comparators = 3, probeType = Data })
 {-# ANN testWithLefts (TestBench 'top) #-}
 {-# ANN testWithLefts (defSyn "testWithLefts") #-}
 
+threeCountersPerProbe ::
+  IlaConfig ->
+  ProbeConfig -> ProbeConfig -> ProbeConfig ->
+  Clock Dom -> Signal Dom ()
+threeCountersPerProbe config pc0 pc1 pc2 clk =
+  setName @"three_counters_ila" $
+    ilaWith @Dom config clk
+      (probeWith "foo"   pc0 counter0)
+      (probeWith "bar"   pc1 counter1)
+      (probeWith "ipsum" pc2 counter2)
+ where
+  counter0 :: Signal Dom (Unsigned 64)
+  counter0 = register clk noReset enableGen 0 (counter0 + 1)
+
+  counter1 :: Signal Dom (Unsigned 64)
+  counter1 = register clk noReset enableGen 0 (counter1 + 2)
+
+  counter2 :: Signal Dom (Unsigned 64)
+  counter2 = register clk noReset enableGen 0 (counter2 + 3)
+
 testWithRights :: Clock Dom -> Signal Dom ()
-testWithRights = threeCounters $
-  (ilaConfig ("foo" :> "bar" :> "ipsum" :> Nil))
-    { comparators = Right (4 :> 5 :> 6 :> Nil)
-    , probeTypes = Right (DataAndTrigger :> Data :> Trigger :> Nil)
-    , depth = D1024
-    , captureControl = True
-    , stages = 3
-    }
+testWithRights = threeCountersPerProbe
+  (ilaConfig { depth = D1024, captureControl = True, stages = 3 })
+  (probeConfig { comparators = 4, probeType = DataAndTrigger })
+  (probeConfig { comparators = 5, probeType = Data })
+  (probeConfig { comparators = 6, probeType = Trigger })
 {-# ANN testWithRights (TestBench 'top) #-}
 {-# ANN testWithRights (defSyn "testWithRights") #-}
 
 testWithRightsSameCu :: Clock Dom -> Signal Dom ()
-testWithRightsSameCu = threeCounters $
-  (ilaConfig ("foo" :> "bar" :> "ipsum" :> Nil))
-    { comparators = Right (4 :> 4 :> 4 :> Nil)
-    , probeTypes = Right (Trigger :> Data :> DataAndTrigger :> Nil)
-    , depth = D4096
-    , captureControl = True
-    , stages = 1
-    , advancedTriggers = True
-    }
+testWithRightsSameCu = threeCountersPerProbe
+  (ilaConfig { depth = D4096, captureControl = True, stages = 1, advancedTriggers = True })
+  (probeConfig { comparators = 4, probeType = Trigger })
+  (probeConfig { comparators = 4, probeType = Data })
+  (probeConfig { comparators = 4, probeType = DataAndTrigger })
 {-# ANN testWithRightsSameCu (TestBench 'top) #-}
 {-# ANN testWithRightsSameCu (defSyn "testWithRightsSameCu") #-}
 
@@ -98,7 +112,7 @@ mainVHDL = do
 
   -- HDL content check:
   let hdlDir = dir </> show 'testWithDefaultsOne
-  [path] <- glob (hdlDir </> "Ila_testWithDefaultsOne_ila.vhdl")
+  [path] <- glob (hdlDir </> "Ila_testWithDefaultsOne_ila*.vhdl")
   contents <- readFile path
   assertIn contents "attribute KEEP of foo : signal is \"true\";" -- signal name
   assertIn contents "one_counter_ila : testWithDefaultsOne_ila"   -- instantiation label
@@ -117,7 +131,7 @@ getTcl nm = do
   let tclPath = topDir </> tclFileName
   readFile tclPath
 
-assertIn :: String -> String -> IO ()
+assertIn :: HasCallStack => String -> String -> IO ()
 assertIn haystack needle
   | needle `isInfixOf` haystack = return ()
   | otherwise = error $ mconcat [ "Expected:\n\n  ", needle

--- a/hdl-tests/shouldwork/Xilinx/T2781.hs
+++ b/hdl-tests/shouldwork/Xilinx/T2781.hs
@@ -3,7 +3,7 @@ module T2781
   ) where
 
 import Clash.Explicit.Prelude
-import Clash.Cores.Xilinx.Ila (IlaConfig(..), Depth(..), ila, ilaConfig)
+import Clash.Cores.Xilinx.Ila (ila, triggerProbe)
 
 fullMeshHwTestDummy ::
   Clock System ->
@@ -17,10 +17,9 @@ fullMeshHwTestDummy sysClk =
   )
  where
   fincFdecIla :: Signal System ()
-  fincFdecIla = ila
-    (ilaConfig ("trigger_0" :> Nil))
+  fincFdecIla = ila @System
     sysClk
-    (pure True :: Signal System Bool)
+    (triggerProbe "trigger_0" (pure True :: Signal System Bool))
 
 -- | Top entity for this test. See module documentation for more information.
 fullMeshSwCcTest ::

--- a/src/Clash/Cores/Xilinx/Ila.hs
+++ b/src/Clash/Cores/Xilinx/Ila.hs
@@ -37,6 +37,8 @@ module Clash.Cores.Xilinx.Ila
   , ilaWith
   , probe
   , probeWith
+  , dataProbe
+  , triggerProbe
 
   -- * Config
   , IlaConfig(..)
@@ -84,6 +86,30 @@ instance Ila dom (Signal dom ()) where
 
 instance Ila dom a => Ila dom (Probe (Signal dom i) -> a) where
   ilaX !_i = ilaX @dom @a
+
+-- | Probe with default config, see 'probeConfig', but with its 'probeType'
+-- set to 'Data'.
+dataProbe ::
+  forall dom a.
+  -- | Probe name
+  String ->
+  -- | Signal to capture
+  Signal dom a ->
+  -- | Probe structure to give to 'Clash.Cores.Xilinx.Ila.ila'
+  Probe (Signal dom a)
+dataProbe name = probeWith name probeConfig{probeType=Data}
+
+-- | Probe with default config, see 'probeConfig', but with its 'probeType'
+-- set to 'DataAndTrigger'.
+triggerProbe ::
+  forall dom a.
+  -- | Probe name
+  String ->
+  -- | Signal to capture
+  Signal dom a ->
+  -- | Probe structure to give to 'Clash.Cores.Xilinx.Ila.ila'
+  Probe (Signal dom a)
+triggerProbe name = probeWith name probeConfig{probeType=DataAndTrigger}
 
 -- | A [polyvariadic](https://github.com/AJFarmar/haskell-polyvariadic) function
 -- that instantiates a Xilinx Integrated Logic Analyzer (ILA).

--- a/src/Clash/Cores/Xilinx/Ila.hs
+++ b/src/Clash/Cores/Xilinx/Ila.hs
@@ -72,6 +72,7 @@ ilaConfig = IlaConfig
   , depth = D4096
   , captureControl = True
   , advancedTriggers = False
+  , exactNames = True
   }
 
 

--- a/src/Clash/Cores/Xilinx/Ila.hs
+++ b/src/Clash/Cores/Xilinx/Ila.hs
@@ -35,10 +35,16 @@ When using the generated ILAs make sure you have set the correct JTAG clock spee
 module Clash.Cores.Xilinx.Ila
   ( ila
   , ilaWith
+
   , probe
   , probeWith
   , dataProbe
   , triggerProbe
+
+  , probeTh
+  , probeWithTh
+  , dataProbeTh
+  , triggerProbeTh
 
   -- * Config
   , IlaConfig(..)
@@ -60,6 +66,8 @@ import Clash.Annotations.Primitive (Primitive (InlineYamlPrimitive))
 import Data.String.Interpolate (__i)
 
 import Clash.Cores.Xilinx.Ila.Internal
+
+import qualified Language.Haskell.TH as TH
 
 -- | A default ILA config that:
 --
@@ -110,6 +118,68 @@ triggerProbe ::
   -- | Probe structure to give to 'Clash.Cores.Xilinx.Ila.ila'
   Probe (Signal dom a)
 triggerProbe name = probeWith name probeConfig{probeType=DataAndTrigger}
+
+-- | Like 'probeWith', but can be used to make sure probe names correspond to
+-- names in the Clash source code. For example, instead of writing:
+--
+-- > probeWith myConfig "foo" foo
+--
+-- You can write:
+--
+-- > $(probeWithTH myConfig 'foo)
+probeWithTh ::
+  -- | Custom config, see 'probeConfig' for defaults
+  ProbeConfig ->
+  -- | Signal name to capture
+  TH.Name ->
+  -- | Probe structure to give to 'Clash.Cores.Xilinx.Ila.ila'
+  TH.Q TH.Exp
+probeWithTh = mkProbeTh 'probe
+
+-- | Like 'probe', but can be used to make sure probe names correspond to
+-- name in the Clash source code. For example, instead of writing:
+--
+-- > probe "foo" foo
+--
+-- You can write:
+--
+-- > $(probeTh 'foo)
+probeTh ::
+  -- | Signal name to capture
+  TH.Name ->
+  -- | Probe structure to give to 'Clash.Cores.Xilinx.Ila.ila'
+  TH.Q TH.Exp
+probeTh = mkProbeTh 'probe probeConfig
+
+-- | Like 'dataProbe', but can be used to make sure probe names correspond to
+-- name in the Clash source code. For example, instead of writing:
+--
+-- > dataProbe "foo" foo
+--
+-- You can write:
+--
+-- > $(dataProbeTh 'foo)
+dataProbeTh ::
+  -- | Signal name to capture
+  TH.Name ->
+  -- | Probe structure to give to 'Clash.Cores.Xilinx.Ila.ila'
+  TH.Q TH.Exp
+dataProbeTh = mkProbeTh 'dataProbe probeConfig
+
+-- | Like 'triggerProbe', but can be used to make sure probe names correspond to
+-- name in the Clash source code. For example, instead of writing:
+--
+-- > triggerProbe "foo" foo
+--
+-- You can write:
+--
+-- > $(triggerProbeTh 'foo)
+triggerProbeTh ::
+  -- | Signal name to capture
+  TH.Name ->
+  -- | Probe structure to give to 'Clash.Cores.Xilinx.Ila.ila'
+  TH.Q TH.Exp
+triggerProbeTh = mkProbeTh 'triggerProbe probeConfig
 
 -- | A [polyvariadic](https://github.com/AJFarmar/haskell-polyvariadic) function
 -- that instantiates a Xilinx Integrated Logic Analyzer (ILA).

--- a/src/Clash/Cores/Xilinx/Ila.hs
+++ b/src/Clash/Cores/Xilinx/Ila.hs
@@ -22,6 +22,9 @@ When using the generated ILAs make sure you have set the correct JTAG clock spee
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE NamedFieldPuns #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE NoFieldSelectors #-}
 {-# LANGUAGE QuasiQuotes #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE ViewPatterns#-}
@@ -31,15 +34,21 @@ When using the generated ILAs make sure you have set the correct JTAG clock spee
 
 module Clash.Cores.Xilinx.Ila
   ( ila
+  , ilaWith
+  , probe
+  , probeWith
 
   -- * Config
   , IlaConfig(..)
   , ilaConfig
+  , ProbeConfig(..)
+  , probeConfig
   , ProbeType(..)
   , Depth(..)
 
   -- * Utilities
   , Ila(..)
+  , Probe(..)
   ) where
 
 import Clash.Explicit.Prelude
@@ -54,18 +63,13 @@ import Clash.Cores.Xilinx.Ila.Internal
 --
 --  * Configures no pipeline registers
 --  * Stores 4096 samples
---  * Sets 2 comparators per probe
---  * Sets all probes to be suited for DATA and TRIGGER
 --  * Enables capture control
 --
 -- See 'IlaConfig' for more information.
-ilaConfig :: Vec n String -> IlaConfig n
-ilaConfig names = IlaConfig
+ilaConfig :: IlaConfig
+ilaConfig = IlaConfig
   { stages = 0
   , depth = D4096
-  , comparators = Left 2
-  , probeTypes = Left DataAndTrigger
-  , probeNames = names
   , captureControl = True
   , advancedTriggers = False
   }
@@ -77,7 +81,7 @@ class Ila (dom :: Domain) a where
 instance Ila dom (Signal dom ()) where
   ilaX = pure ()
 
-instance Ila dom a => Ila dom (Signal dom i -> a) where
+instance Ila dom a => Ila dom (Probe (Signal dom i) -> a) where
   ilaX !_i = ilaX @dom @a
 
 -- | A [polyvariadic](https://github.com/AJFarmar/haskell-polyvariadic) function
@@ -92,11 +96,16 @@ instance Ila dom a => Ila dom (Signal dom i -> a) where
 --   'Signal' dom ('Unsigned' 8) ->
 --   'Signal' dom ('Unsigned' 8)
 -- myAdder a b = ilaOut \`'hwSeqX'\` c
--- where
---  c = a + b
+--  where
+--   c = a + b
 --
---  ilaOut :: Signal dom ()
---  ilaOut = 'ila' ('ilaConfig' ("a" :> "b" :> "add_result" :> Nil)) clk a b c
+--   ilaOut :: Signal dom ()
+--   ilaOut =
+--     'ila'
+--       clk
+--       ('probe' "a" a)
+--       ('probe' "b" b)
+--       ('probe' "c" c)
 -- @
 --
 -- Note that signal names do not have to correspond to names passed to the ILA.
@@ -104,9 +113,8 @@ instance Ila dom a => Ila dom (Signal dom i -> a) where
 -- __N.B.__ Use 'Clash.XException.hwSeqX' to make sure the ILA does not get
 --          optimized away by GHC.
 ila ::
-  forall dom a n .
-  (KnownDomain dom, Ila dom a, 1 <= n) =>
-  IlaConfig n ->
+  forall dom a .
+  (KnownDomain dom, Ila dom a) =>
   -- | Clock to sample inputs on. Note that this is not necessarily the clock
   -- Xilinx's debug hub will run at, if multiple ILAs are instantiated.
   Clock dom ->
@@ -114,24 +122,38 @@ ila ::
   -- @Signal dom ()@. You need to make sure this does not get optimized away by
   -- GHC by using 'Clash.XException.hwSeqX'.
   a
-ila conf clk =
-  ila# @dom @a conf clk
-{-# OPAQUE ila #-}
+ila clk = ilaWith ilaConfig clk
+{-# INLINE ila #-}
+
+-- | Like 'ila', but takes an 'IlaConfig'.
+ilaWith ::
+  forall dom a .
+  (KnownDomain dom, Ila dom a) =>
+  IlaConfig ->
+  -- | Clock to sample inputs on. Note that this is not necessarily the clock
+  -- Xilinx's debug hub will run at, if multiple ILAs are instantiated.
+  Clock dom ->
+  -- | Any number of 'Signal' arguments. The result will always be
+  -- @Signal dom ()@. You need to make sure this does not get optimized away by
+  -- GHC by using 'Clash.XException.hwSeqX'.
+  a
+ilaWith config clk = ila# @dom @a config clk
+{-# OPAQUE ilaWith #-}
 
 -- | Primitive for 'ila'. Defining a wrapper like this makes the ILA
 -- instantiation be rendered in its own module to reduce naming collision
 -- probabilities.
 ila# ::
-  forall dom a n .
-  (KnownDomain dom, Ila dom a, 1 <= n) =>
-  IlaConfig n ->
+  forall dom a .
+  (KnownDomain dom, Ila dom a) =>
+  IlaConfig ->
   Clock dom ->
   a
 ila# !_conf !_clk = ilaX @dom @a
 {-# OPAQUE ila# #-}
 {-# ANN ila# (
     let primName = 'ila#
-        tfName = 'ilaBBF
+        tfName = 'ilaBbf
     in InlineYamlPrimitive [minBound..] [__i|
          BlackBoxHaskell:
              name: #{primName}

--- a/src/Clash/Cores/Xilinx/Ila/Internal.hs
+++ b/src/Clash/Cores/Xilinx/Ila/Internal.hs
@@ -23,6 +23,8 @@ module Clash.Cores.Xilinx.Ila.Internal where
 import Prelude
 import qualified Clash.Prelude as C
 
+import Language.Haskell.TH (Name, Q, Exp, nameBase, varE, stringE)
+
 import Clash.Annotations.SynthesisAttributes (Attr(StringAttr))
 import Clash.Backend (Backend)
 import Clash.Core.Term (Term)
@@ -137,6 +139,23 @@ probeWith ::
   -- | Probe structure to give to 'Clash.Cores.Xilinx.Ila.ila'
   Probe (C.Signal dom a)
 probeWith name config signal = Probe{name, config, signal}
+
+-- | Template Haskell helper used by @probeTh@, @dataProbeTh@, @triggerProbeTh@,
+-- and @probeWithTh@. Generates a call to 'probeWith' using the base name of the
+-- given signal variable as the probe name:
+--
+-- > mkProbeTh cfg 'foo  ===  probeWith cfg "foo" foo
+mkProbeTh ::
+  -- | Probe function (e.g. @'probe@, @'dataProbe@) — ignored; the generated
+  -- expression always calls 'probeWith' directly.
+  Name ->
+  -- | Probe configuration
+  ProbeConfig ->
+  -- | Name of the signal variable to probe
+  Name ->
+  Q Exp
+mkProbeTh _probeFn cfg signalName =
+  [| probeWith cfg $(stringE (nameBase signalName)) $(varE signalName) |]
 
 -- | Configures the static properties of an 'Clash.Cores.Xilinx.Ila.ila'. Note
 -- that most properties (triggers, number of samples before/after trigger, ...)

--- a/src/Clash/Cores/Xilinx/Ila/Internal.hs
+++ b/src/Clash/Cores/Xilinx/Ila/Internal.hs
@@ -7,6 +7,7 @@
   Black box implementation for primitives in "Clash.Cores.Xilinx.Ila".
 -}
 
+{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveLift #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE NamedFieldPuns #-}
@@ -22,38 +23,30 @@ module Clash.Cores.Xilinx.Ila.Internal where
 import Prelude
 import qualified Clash.Prelude as C
 
-import Control.Monad (when, zipWithM)
+import Clash.Annotations.SynthesisAttributes (Attr(StringAttr))
+import Clash.Backend (Backend)
+import Clash.Core.Term (Term)
+import Clash.Core.TermLiteral (TermLiteral(..), deriveTermLiteral)
+import Clash.Core.TermLiteral.Compat (termToDataError)
+import Clash.Netlist.BlackBox.Types
+import Clash.Netlist.Types
+import Control.Monad (zipWithM)
 import Control.Monad.State (State)
-import Data.Either (lefts, rights)
-import Data.List (zip4, group)
+import Data.Either (lefts)
+import Data.List (zip4)
 import Data.List.Infinite((...), Infinite((:<)))
-import Data.Proxy (Proxy(..))
-import Data.String.Interpolate (__i)
 import Data.Maybe (isJust)
+import Data.String.Interpolate (__i)
 import Data.Text.Prettyprint.Doc.Extra (Doc)
 import GHC.Stack (HasCallStack)
-import GHC.TypeLits (KnownNat, SomeNat(..), someNatVal)
 import Language.Haskell.TH.Syntax (Lift)
 import Text.Show.Pretty (ppShow)
 
-import qualified Control.Lens as Lens
 import qualified Data.List.Infinite as Infinite
 import qualified Data.Text as T
-
-import Clash.Annotations.SynthesisAttributes (Attr(StringAttr))
-import Clash.Backend (Backend)
-import Clash.Netlist.Types
-import Clash.Netlist.BlackBox.Types
-import Clash.Core.TermLiteral (TermLiteral(..), deriveTermLiteral)
-import Clash.Core.TermLiteral.TH (deriveTermToData)
-import Clash.Core.Type (Type(LitTy), LitTy(NumTy), coreView)
-import Clash.Sized.Vector (Vec)
-
 import qualified Clash.Netlist.Id as Id
 import qualified Clash.Primitives.DSL as DSL
-import qualified Clash.Util.Interpolate as I
 
-import Clash.Core.TermLiteral.Compat (termToDataError)
 import Clash.Cores.Xilinx.Internal
   ( TclPurpose(..)
   , IpConfig(..)
@@ -94,6 +87,57 @@ data ProbeType
   -- ^ Probe can only be used to trigger data capture
   deriving (Eq, Show, Lift, Enum)
 
+data ProbeConfig = ProbeConfig
+  { comparators :: Word
+  -- ^ Number of comparators to instantiate for trigger probes. Should from 1 up to
+  -- and including 16. This limits the number of conditions that can be used to
+  -- trigger capture.
+  , probeType :: ProbeType
+  -- ^ Capabilities of the probe
+  }
+  deriving (Eq, Show, Lift)
+
+-- | Default probe config. Probes can be used for both data and trigger. The number
+-- of comparators is set to two.
+probeConfig :: ProbeConfig
+probeConfig = ProbeConfig{comparators=2, probeType=DataAndTrigger}
+
+data Probe a = Probe
+  { -- XXX: Keep signal as the first field! The blackbox implementation relies on it.
+    signal :: a
+  -- ^ Signal that the probe is attached to
+  , name :: String
+  -- ^ Name of ILA probe. This is the name that shows up when querying the ILA through
+  -- the GUI or TCL interface.
+  , config :: ProbeConfig
+  -- ^ Probe specific configuration options
+  }
+  deriving (Eq, Show, Lift, Functor)
+
+-- | Probe with default config, see 'probeConfig'.
+probe ::
+  forall dom a.
+  -- | Probe name
+  String ->
+  -- | Signal to capture
+  C.Signal dom a ->
+  -- | Probe structure to give to 'Clash.Cores.Xilinx.Ila.ila'
+  Probe (C.Signal dom a)
+probe name = probeWith name probeConfig
+
+-- | Like 'probe', but with a custom configuration
+probeWith ::
+  forall dom a.
+  -- | Probe name
+  String ->
+  -- | Custom config, see 'probeConfig' for defaults
+  ProbeConfig ->
+  -- | Signal to capture
+  C.Signal dom a ->
+  -- | Probe structure to give to 'Clash.Cores.Xilinx.Ila.ila'
+  Probe (C.Signal dom a)
+probeWith name config signal = Probe{name, config, signal}
+
 -- | Configures the static properties of an 'Clash.Cores.Xilinx.Ila.ila'. Note
 -- that most properties (triggers, number of samples before/after trigger, ...)
 -- are configured at runtime using Vivado. When applicable, configuration fields
@@ -102,10 +146,8 @@ data ProbeType
 --
 -- Use 'Clash.Cores.Xilinx.Ila.ilaConfig' to construct this with some sensible
 -- defaults.
-data IlaConfig n = IlaConfig
-  { probeNames :: Vec n String
-  -- ^ Probe names. Clash will error if it cannot generate names passed here.
-  , depth :: Depth
+data IlaConfig = IlaConfig
+  { depth :: Depth
   -- ^ Number of samples to store. Corresponds to @C_DATA_DEPTH@.
   , captureControl :: Bool
   -- ^ Whether probes marked 'Trigger' or 'DataAndTrigger' can be used to control
@@ -114,18 +156,6 @@ data IlaConfig n = IlaConfig
   , stages :: C.Index 7
   -- ^ Number of registers to insert at each probe. Supported values: 0-6.
   -- Corresponds to @C_INPUT_PIPE_STAGES@.
-  , comparators :: Either Int (Vec n Int)
-  -- ^ Comparators available at each probe. If 'Left', all probes will get the
-  -- same number of comparators. If 'Right', each probe gets a configurable
-  -- number of comparators. Supported values: 2 - 16. Corresponds to
-  -- @C_PROBE<n>_MU_CNT@
-  --
-  -- __N.B.__: Xilinx strongly recommends to use the same number of comparators
-  --           for every probe (without explanation).
-  , probeTypes :: Either ProbeType (Vec n ProbeType)
-  -- ^ Purpose of probe. If 'Left', all probes will be set to the same type. If
-  -- 'Right', each probe type can be set individually. Also see 'ProbeType'.
-  -- Corresponds to @C_PROBE<n>_TYPE@.
   , advancedTriggers :: Bool
   -- ^  Whether state machines can be used to describe trigger logic.
   -- Corresponds to @C_ADV_TRIGGER@.
@@ -134,52 +164,47 @@ data IlaConfig n = IlaConfig
 
 -- XXX: I'd move this 'deriveTermLiteral' up, but Template Haskell complains..
 deriveTermLiteral ''ProbeType
+deriveTermLiteral ''ProbeConfig
+deriveTermLiteral ''Probe
 deriveTermLiteral ''Depth
-instance KnownNat n => TermLiteral (IlaConfig n) where
-  termToData = $(deriveTermToData ''IlaConfig)
+deriveTermLiteral ''IlaConfig
 
-probeTypesVec :: KnownNat n => IlaConfig n -> Vec n ProbeType
-probeTypesVec = either C.repeat id . probeTypes
-
-comparatorsVec :: KnownNat n => IlaConfig n -> Vec n Int
-comparatorsVec = either C.repeat id . comparators
-
--- | Are all values in a list equal? If so, return the element.
-areEqual :: Eq a => [a] -> Maybe a
-areEqual = \case { [x:_] -> Just x; _ -> Nothing } . group
-
-ilaBBF :: HasCallStack => BlackBoxFunction
-ilaBBF _isD _primName args _resTys = Lens.view tcCache >>= go
+ilaBbf :: HasCallStack => BlackBoxFunction
+ilaBbf _isD _primName args _resTys = pure $
+  case lefts args of
+    (_:_:config:_clock:userArgs) ->
+      case termToDataError @IlaConfig config of
+        Left s -> Left ("ilaBbf, bad config:\n" <> s)
+        Right c ->
+          case traverse (termToDataError @(Probe Term)) userArgs of
+            Left s -> Left $ ("ilaBbf, bad probes:\n" <> s)
+            Right probes -> Right (bbMeta c (map eraseTerm probes), bb c (map eraseTerm probes))
+    _ ->
+      Left $ "ilaBbf, bad args:\n" <> ppShow args
  where
-  go tcm
-    | _:_:_:config:_ <- lefts args
-    , _:_:(coreView tcm -> LitTy (NumTy n)):_ <- rights args
-    , Just (SomeNat (Proxy :: Proxy n)) <- someNatVal n
-    = case termToDataError @(IlaConfig n) config of
-        Left s -> error ("ilaBBF, bad config:\n" <> s)
-        Right c -> pure $ Right (bbMeta c, bb c)
-    | otherwise = error $ "ilaBBF, bad args:\n" <> ppShow args
 
-  bbMeta :: KnownNat n => IlaConfig n -> BlackBoxMeta
-  bbMeta config = emptyBlackBoxMeta
+  bbMeta :: IlaConfig -> [Probe ()] -> BlackBoxMeta
+  bbMeta config probes = emptyBlackBoxMeta
     { bbKind = TDecl
     , bbRenderVoid = RenderVoid
     , bbIncludes =
         [ ( ("ila", "clash.tcl")
-          , BBFunction (show 'ilaTclTF) 0 (ilaTclTF config)
+          , BBFunction (show 'ilaTclTf) 0 (ilaTclTf config probes)
           )
         ]
     }
 
-  bb :: KnownNat n => IlaConfig n -> BlackBox
-  bb config = BBFunction (show 'ilaTF) 0 (ilaTF config)
+  eraseTerm :: Probe Term -> Probe ()
+  eraseTerm p = const () <$> p
+
+  bb :: IlaConfig -> [Probe ()] -> BlackBox
+  bb config probes = BBFunction (show 'ilaTf) 0 (ilaTf config probes)
 
 usedArguments :: [Int]
 usedArguments = ilaConfig : clock : inputProbes
  where
   (    _knownDomain
     :< _ilaConstraint
-    :< _1nConstraint
     :< ilaConfig
     :< clock
     :< (Infinite.take 8096 -> inputProbes)
@@ -188,18 +213,33 @@ usedArguments = ilaConfig : clock : inputProbes
                -- when forcing this argument to NF we limit it to a modest
                -- 8096 input ports.
 
-ilaTF :: (HasCallStack, KnownNat n) => IlaConfig n -> TemplateFunction
-ilaTF config = TemplateFunction usedArguments (const True) (ilaBBTF config)
+ilaTf :: HasCallStack => IlaConfig -> [Probe ()] -> TemplateFunction
+ilaTf config probes = TemplateFunction usedArguments (const True) (ilaBbTf config probes)
+
+ilaTclTf :: HasCallStack => IlaConfig -> [Probe ()] -> TemplateFunction
+ilaTclTf config probes = TemplateFunction usedArguments (const True) (ilaTclBbTf config probes)
+
+-- | Are all values in a list equal? If so, return the element.
+areEqual :: Eq a => [a] -> Maybe a
+areEqual [] = Nothing
+areEqual (ref:as) = go as
+ where
+  go [] = Just ref
+  go (a:rest)
+    | ref == a = go rest
+    | otherwise = Nothing
+
+--  \case { (x:_):_ -> Just x; _ -> Nothing } . group
 
 checkNameCollision :: HasCallStack => T.Text -> DSL.TExpr -> DSL.TExpr
 checkNameCollision userName tExpr@(DSL.TExpr _ (Identifier (Id.toText -> name) Nothing))
   | userName == name = tExpr
-  | otherwise = error [I.i|
+  | otherwise = error [__i|
       Tried create a signal called '#{userName}', but identifier generation
-      returned '#{name}'. Refusing to instantiate Ila with unreliable probe
+      returned '#{name}'. Refusing to instantiate ILA with unreliable probe
       names.
   |]
-checkNameCollision _ tExpr = error [I.i|
+checkNameCollision _ tExpr = error [__i|
   Internal error: Expected 'TExpr' with the following form:
 
     TExpr _ (Identifier _ Nothing)
@@ -209,46 +249,52 @@ checkNameCollision _ tExpr = error [I.i|
     #{ppShow tExpr}
 |]
 
-ilaBBTF ::
-  forall s n .
-  (Backend s, KnownNat n, HasCallStack) =>
-  IlaConfig n ->
+-- | Return user-friendly ILA instance name given a context name hint.
+-- We ignore @__VOID_TDECL_NOOP__@, created by @mkPrimitive@ whenever a user
+-- hint is not given and the primitive returns a zero-width type.
+getIlaName :: Maybe T.Text -> T.Text
+getIlaName Nothing = "ila_inst"
+getIlaName (Just "result") = getIlaName Nothing
+getIlaName (Just "__VOID_TDECL_NOOP__") = getIlaName Nothing
+getIlaName (Just s) = s
+
+-- | Extract the signal 'TExpr' from a 'Probe' product in the blackbox context.
+-- 'signal' is the first field of 'Probe', so it's the first expression in the
+-- DataCon application.
+toProbeExpr :: DSL.TExpr -> DSL.TExpr
+toProbeExpr (DSL.TExpr{eex=DataCon (Product _ _ (signalType:_)) _ (signalExpr:_)}) =
+  DSL.TExpr{eex=signalExpr, ety=signalType}
+toProbeExpr tExpr =
+  error $ "toProbeExpr: Unexpected probe expression: " <> ppShow tExpr
+
+ilaBbTf ::
+  forall s .
+  (Backend s, HasCallStack) =>
+  IlaConfig ->
+  [Probe ()] ->
   BlackBoxContext ->
   State s Doc
-ilaBBTF config bbCtx
+ilaBbTf _config probes bbCtx
   | (   _knownDomainDom
       : _ilaConstraint
-      : _1nConstraint
       : _ilaConfig
       : clk
-      : inputs
+      : (map toProbeExpr -> inPs)
       ) <- map fst $ DSL.tInputs bbCtx
   , [ilaName] <- bbQsysIncName bbCtx
-  , let inTys = map DSL.ety inputs
   = do
-      let userInputNames = T.pack <$> C.toList (probeNames config)
-
-      when (length inTys /= C.natToNum @n) $
-        error [I.i|
-          Number of input names did not match number of input probes. Expected
-          #{length inTys} input name(s), got #{length userInputNames}. Got input
-          name(s):
-
-            #{ppShow userInputNames}
-        |]
-
       ilaInstName <- Id.makeBasic (getIlaName (bbCtxName bbCtx))
 
       let
-        inPs = filter ((> (0 :: Int)) . DSL.tySize . DSL.ety) inputs
         inNames = map (T.pack . ("probe" <>) . show) [(0 :: Int)..]
-        inBVs = map (BitVector . (fromInteger . DSL.tySize . DSL.ety)) inPs
+        inBVs   = map (BitVector . fromInteger . DSL.tySize . DSL.ety) inPs
+        userProbeNames = map (T.pack . (\Probe{name=n} -> n)) probes
 
       DSL.declarationReturn bbCtx "ila_inst_block" $ do
         DSL.compInBlock ilaName (("clk", Bit) : zip inNames inBVs) []
 
-        inProbes <- zipWithM DSL.assign inNames inPs
-        inProbesBV <- zipWithM toNameCheckedBv userInputNames inProbes
+        inProbes   <- zipWithM DSL.assign inNames inPs
+        inProbesBV <- zipWithM toNameCheckedBv userProbeNames inProbes
 
         DSL.instDecl
           Empty
@@ -260,56 +306,38 @@ ilaBBTF config bbCtx
 
         pure []
 
-  | otherwise = error $ "ilaBBTF, bad bbCtx: " <> ppShow bbCtx
+  | otherwise = error "ilaBbTf: bad bbCtx"
  where
-  -- The HDL attribute 'KEEP' is added to the signals connected to the
-  -- probe ports so they are not optimized away by the synthesis tool.
+  -- The HDL attribute 'KEEP' is added to signals connected to probe ports so
+  -- they are not optimized away by the synthesis tool.
   keepAttrs = [StringAttr "KEEP" "true"]
 
   toNameCheckedBv nameHint inProbe =
     checkNameCollision nameHint <$>
       DSL.toBvWithAttrs keepAttrs nameHint inProbe
 
-  -- Return user-friendly name given a context name hint. Note that we ignore
-  -- @__VOID_TDECL_NOOP__@. It is created by 'mkPrimitive' whenever a user hint
-  -- is _not_ given and the primitive returns a zero-width type.
-  getIlaName :: Maybe T.Text -> T.Text
-  getIlaName Nothing = "ila_inst"
-  getIlaName (Just "result") = getIlaName Nothing
-  getIlaName (Just "__VOID_TDECL_NOOP__") = getIlaName Nothing
-  getIlaName (Just s) = s
-
-ilaTclTF :: (HasCallStack, KnownNat n) => IlaConfig n -> TemplateFunction
-ilaTclTF config = TemplateFunction usedArguments (const True) (ilaTclBBTF config)
-
-ilaTclBBTF ::
-  forall s n .
-  (HasCallStack, KnownNat n, Backend s) =>
-  IlaConfig n ->
+ilaTclBbTf ::
+  forall s .
+  (HasCallStack, Backend s) =>
+  IlaConfig ->
+  [Probe ()] ->
   BlackBoxContext ->
   State s Doc
-ilaTclBBTF config@IlaConfig{..} bbCtx
+ilaTclBbTf IlaConfig{depth, captureControl, advancedTriggers, stages} probes bbCtx
   | [ilaName] <- bbQsysIncName bbCtx
-  , (   _knownDomainDom
-    : _IlaConstraint
-    : _1nConstraint
-    : _ilaConfig
-    : _clk
-    : inputs
-    ) <- map fst $ DSL.tInputs bbCtx
-  , let inTys = map DSL.ety inputs
   = pure $ renderTcl $ pure $ IpConfigPurpose $
-      (defIpConfig "ila" "6.2" ilaName){properties=properties inTys}
-  | otherwise = error $ "ilaBBTF, bad bbCtx:\n\n" <> ppShow bbCtx
+      (defIpConfig "ila" "6.2" ilaName){properties = properties}
+  | otherwise = error $ "ilaTclBbTf: bad bbCtx:\n\n" <> ppShow bbCtx
  where
-  probesTypesL = C.toList (probeTypesVec config)
-  compsL = C.toList (comparatorsVec config)
-  sameMu = areEqual compsL
+  probeConfigs = map (\Probe{config=c} -> c) probes
+  comps        = map comparators probeConfigs
+  types        = map probeType   probeConfigs
+  sameMu       = areEqual comps
 
-  properties inTys = globalProperties inTys <> portProperties inTys
+  properties = globalProperties <> portProperties
 
-  globalProperties inTys =
-    [ property @Int  "C_NUM_OF_PROBES" (length inTys)
+  globalProperties =
+    [ property @Int  "C_NUM_OF_PROBES" (length probes)
     , property @Word "C_INPUT_PIPE_STAGES" (fromIntegral stages)
     , property @Word "C_DATA_DEPTH" (depthToWord depth)
     , property @Bool "ALL_PROBE_SAME_MU" (isJust sameMu)
@@ -317,14 +345,18 @@ ilaTclBBTF config@IlaConfig{..} bbCtx
     , property @Bool "C_TRIGIN_EN" False
     , property @Bool "C_ADV_TRIGGER" advancedTriggers
     ] <>
-    [ property @Int "ALL_PROBE_SAME_MU_CNT" mu | Just mu <- [sameMu]
-    ]
+    [ property @Word "ALL_PROBE_SAME_MU_CNT" mu | Just mu <- [sameMu] ]
 
-  portProperties inTys = concat $
-    [ [ property @Int [__i|C_PROBE#{i}_WIDTH|] width
-      , property @Int [__i|C_PROBE#{i}_TYPE|] (fromEnum probeType)
-      , property @Int [__i|C_PROBE#{i}_MU_CNT|] compC
+  portProperties = concat
+    [ [ property @Int  [__i|C_PROBE#{i}_WIDTH|]  width
+      , property @Int  [__i|C_PROBE#{i}_TYPE|]   (fromEnum pt)
+      , property @Word [__i|C_PROBE#{i}_MU_CNT|] comp
       ]
-    | (i, ty, probeType, compC) <- zip4 [(0 :: Int)..] inTys probesTypesL compsL
-    , let width = fromInteger $ DSL.tySize ty
+    | (i, tExpr, pt, comp) <-
+        zip4
+          [(0 :: Int)..]
+          (map toProbeExpr . drop 4 . map fst $ DSL.tInputs bbCtx)
+          types
+          comps
+    , let width = DSL.tySize (DSL.ety tExpr)
     ]

--- a/src/Clash/Cores/Xilinx/Ila/Internal.hs
+++ b/src/Clash/Cores/Xilinx/Ila/Internal.hs
@@ -159,6 +159,11 @@ data IlaConfig = IlaConfig
   , advancedTriggers :: Bool
   -- ^  Whether state machines can be used to describe trigger logic.
   -- Corresponds to @C_ADV_TRIGGER@.
+  , exactNames :: Bool
+  -- ^ If set, require probe names to match variable names in the generated HDL
+  -- exactly. If Clash cannot do this, an error will be thrown. If not set,
+  -- the ILA will continue to work correctly, though names might have suffixes
+  -- (@_1@, @_2@, etc.).
   }
   deriving (Show, Lift)
 
@@ -274,7 +279,7 @@ ilaBbTf ::
   [Probe ()] ->
   BlackBoxContext ->
   State s Doc
-ilaBbTf _config probes bbCtx
+ilaBbTf IlaConfig{exactNames} probes bbCtx
   | (   _knownDomainDom
       : _ilaConstraint
       : _ilaConfig
@@ -312,9 +317,11 @@ ilaBbTf _config probes bbCtx
   -- they are not optimized away by the synthesis tool.
   keepAttrs = [StringAttr "KEEP" "true"]
 
-  toNameCheckedBv nameHint inProbe =
-    checkNameCollision nameHint <$>
-      DSL.toBvWithAttrs keepAttrs nameHint inProbe
+  toNameCheckedBv nameHint inProbe
+    | exactNames = checkNameCollision nameHint <$> bvs
+    | otherwise = bvs
+   where
+    bvs = DSL.toBvWithAttrs keepAttrs nameHint inProbe
 
 ilaTclBbTf ::
   forall s .

--- a/src/Clash/Cores/Xilinx/Xpm/Cdc/Internal.hs
+++ b/src/Clash/Cores/Xilinx/Xpm/Cdc/Internal.hs
@@ -107,12 +107,12 @@ data Param (name :: Symbol) a = Param a
 -- is mapped in the target HDL.
 data ClockPort (portName :: Symbol) dom = ClockPort (Clock dom)
 
--- | Port with differential clock type, which gets 2 ports on hardware for a possitive
+-- | Port with differential clock type, which gets 2 ports on hardware for a positive
 -- and a negative phase. The @portName@ gets the suffix @_p@ and @_n@ respectively
 -- for the ports in the target HDL. For custom suffixes use 'NamedDiffClockPort'.
 data DiffClockPort (portName :: Symbol) dom = DiffClockPort (DiffClock dom)
 
--- | Port with differential clock type, which gets 2 ports on hardware for a possitive
+-- | Port with differential clock type, which gets 2 ports on hardware for a positive
 -- and a negative phase. The @portNameP@ and @portNameN@ are the names of these ports
 -- in the target HDL.
 data NamedDiffClockPort (portNameP :: Symbol) (portNameN :: Symbol) dom =


### PR DESCRIPTION
Before this patch, ILAs would be instantiated as follows:

```haskell
ila
  (ilaConfig ("a" :> "b" :> Nil)
  clk
  a
  b
```

I.e., probe names (and optional config) are syntactically far away from the place where probe signals are given to the function. With the new structure this now looks like:

```haskell
ila
  clk
  (probe "a" a)
  (probe "b" b)
```

It is possible to customize behavior using either `ilaWith` or `probeWith`.

--------------

This PR offers a bunch of smaller patches:

* Fixing a typo
* Adding an option to disable the "exact name" check
* Convenience functions for data/trigger probes
* TH functions to help maintain consistency between probe names and source names

It is based on #61 because I didn't want to cause merge conflicts for myself, but I'll rebase on `main` if that's shot down of course.