### PR TITLE
Use GHC version that match current nixpkgs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ghc-version: [ "ghc9101", "ghc982", "ghc964" ]
+        ghc-version: [ "ghc9103", "ghc984", "ghc967" ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
     runs-on: self-hosted
     strategy:
       matrix:
-        ghc-version: [ "ghc9101", "ghc982", "ghc964" ]
+        ghc-version: [ "ghc9103", "ghc984", "ghc967" ]
     steps:
         # There's no need to configure Nix, the dockerfile handling the GHA has it done for us!
         # If a dependencies are already cached, we can simply re-use them!


### PR DESCRIPTION
I broke it in https://github.com/clash-lang/clash-cores/pull/60 using `nix flake update`..